### PR TITLE
bump gomaasclient version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/ionutbalutoiu/gomaasclient v0.0.0-20210707081625-0c69fffd5a8c
 	github.com/stretchr/testify v1.7.0
 )
+
+replace github.com/ionutbalutoiu/gomaasclient => github.com/maas/gomaasclient v0.0.0-20220614142745-556bd092b2db

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,6 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/ionutbalutoiu/gomaasclient v0.0.0-20210707081625-0c69fffd5a8c h1:BUlfd505LBka9F3Z9QvV6LNtNtTJ0S7YnwLBJiExPfM=
-github.com/ionutbalutoiu/gomaasclient v0.0.0-20210707081625-0c69fffd5a8c/go.mod h1:bj39184ChgZMBH01zYHoUV2h4mSmAYisQSHs/sRzYQE=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
@@ -275,6 +273,8 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LE
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lunixbochs/vtclean v0.0.0-20160125035106-4fbf7632a2c6/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
+github.com/maas/gomaasclient v0.0.0-20220614142745-556bd092b2db h1:w8UyT4Qdqu4T8bwStuWIDydoSfCYtnCLeAKNUyb2tmY=
+github.com/maas/gomaasclient v0.0.0-20220614142745-556bd092b2db/go.mod h1:bj39184ChgZMBH01zYHoUV2h4mSmAYisQSHs/sRzYQE=
 github.com/masterzen/azure-sdk-for-go v3.2.0-beta.0.20161014135628-ee4f0065d00c+incompatible/go.mod h1:mf8fjOu33zCqxUjuiU3I8S1lJMyEAlH+0F2+M5xl3hE=
 github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=
 github.com/masterzen/winrm v0.0.0-20161014151040-7a535cd943fc/go.mod h1:CfZSN7zwz5gJiFhZJz49Uzk7mEBHIceWmbFmYx7Hf7E=


### PR DESCRIPTION
Fixes https://github.com/maas/terraform-provider-maas/issues/13 and points the gomaasclient module at the repo under the MAAS org.