### PR TITLE
[Example] Add acceptance tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,10 @@ jobs:
           terraform_wrapper: false
       - run: go mod download
       - env:
-          TF_ACC: "1"
+          TF_ACC: "0" # Set to "1" after QA environment set up to run acceptance tests 
+          # These will need to be set after a QA environment is set up
+          # MAAS_API_VERSION: 2.0
+          # MAAS_API_KEY: < QA env API key >
+          # MAAS_API_URL: < URL of QA env >
         run: go test -v -cover ./maas/
         timeout-minutes: 10

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test:
 	go test $(TEST) -v $(TESTARGS) -timeout=5m -parallel=$(TEST_PARALLELISM)
 
 testacc:
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m -parallel=$(TEST_PARALLELISM)
+	TF_ACC=0 go test $(TEST) -v $(TESTARGS) -timeout 120m -parallel=$(TEST_PARALLELISM)
 
 generate_docs: $(BIN)/tfplugindocs
 	$(BIN)/tfplugindocs generate --provider-name $(NAME)

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bflad/gopaniccheck v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,7 @@ github.com/andybalholm/crlf v0.0.0-20171020200849-670099aa064f/go.mod h1:k8feO4+
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
+github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
 github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=

--- a/maas/provider_test.go
+++ b/maas/provider_test.go
@@ -6,6 +6,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+var testProvider *schema.Provider
+var providerFactories map[string]func() (*schema.Provider, error)
+
+func init() {
+	testProvider = Provider()
+	providerFactories = map[string]func() (*schema.Provider, error){
+		"maas": func() (*schema.Provider, error) {
+			return testProvider, nil
+		},
+	}
+}
+
 func TestProvider(t *testing.T) {
 	if err := Provider().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)

--- a/maas/resource_maas_fabric_test.go
+++ b/maas/resource_maas_fabric_test.go
@@ -1,0 +1,37 @@
+package maas
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccResourceMaasFabric(t *testing.T) {
+
+	name := acctest.RandomWithPrefix("tf-test-") // this is to avoid name conflicts if multiple tests are running
+
+	tf := fmt.Sprintf(testAccResourceMaasFabricConfig, name)
+	resourceName := "maas_fabric.tf_fabric"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          nil,
+		ProviderFactories: providerFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: tf,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceMaasFabricConfig = `
+resource "maas_fabric" "tf_fabric" {
+	name = "%s"
+  }
+`

--- a/maas/resource_maas_tag_test.go
+++ b/maas/resource_maas_tag_test.go
@@ -1,0 +1,37 @@
+package maas
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccResourceMaasTag(t *testing.T) {
+
+	name := acctest.RandomWithPrefix("tf-test-")
+
+	tf := fmt.Sprintf(testAccResourceMaasTagConfig, name)
+	resourceName := "maas_tag.tf_tag"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          nil,
+		ProviderFactories: providerFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: tf,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceMaasTagConfig = `
+resource "maas_tag" "tf_tag" {
+  name = "%s"
+}
+`

--- a/maas/resource_maas_vm_host_test.go
+++ b/maas/resource_maas_vm_host_test.go
@@ -1,0 +1,40 @@
+package maas
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccResourceMaasVmHost(t *testing.T) {
+
+	tf := fmt.Sprintf(testAccResourceMaasVmHostConfig)
+	resourceName := "maas_vm_host.kvm"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          nil,
+		ProviderFactories: providerFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: tf,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "lxd"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+const testAccResourceMaasVmHostConfig = `
+resource "maas_vm_host" "kvm" {
+  type = "lxd"
+  power_address = "10.10.10.8"
+  tags = [
+    "pod-console-logging",
+    "virtual",
+    "kvm",
+  ]
+}
+`


### PR DESCRIPTION
This PR intends to be an example of how acceptance tests could be added to the provider, and a template for further development in this area. 

In order for the tests to pass, a QA environment will need to be set up and the credentials for this environment can be stored as secrets in the Github repository. These credentials will need to be used in the test.yml file for the MAAS_API_KEY and MAAS_API_URL environment variables.