### PR TITLE
docs: fix min go version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the source code for the Terraform MAAS provider.
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 0.13.x
-- [Go](https://golang.org/doc/install) >= 1.16
+- [Go](https://golang.org/doc/install) >= 1.18
 
 ## Build The Provider
 


### PR DESCRIPTION
go.mod has go 1.18