### PR TITLE
all: update Go module to Go 1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the source code for the Terraform MAAS provider.
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 0.13.x
-- [Go](https://golang.org/doc/install) >= 1.18
+- [Go](https://golang.org/doc/install) >= 1.20
 
 ## Build The Provider
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-maas
 
-go 1.19
+go 1.20
 
 require (
 	github.com/bflad/tfproviderlint v0.28.1


### PR DESCRIPTION
In order to use recent version of Terraform plugin SDK [0] we need to bump our minimal Go version to 1.20 because of this PR [1] being merged.

Also each major Go release is supported until there are two newer major releases [2].

[0]: github.com/hashicorp/terraform-plugin-sdk/v2
[1]: https://github.com/maas/terraform-provider-maas/pull/83
[2]: https://go.dev/doc/devel/release#policy