### PR TITLE
Bump gomaasclient/gomaasapi to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0
-	github.com/maas/gomaasclient v0.0.0-20230912053103-eb0ecc7ab134
+	github.com/maas/gomaasclient v0.0.0-20230927145110-b2775d1ca870
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LE
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lunixbochs/vtclean v0.0.0-20160125035106-4fbf7632a2c6/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
-github.com/maas/gomaasclient v0.0.0-20230912053103-eb0ecc7ab134 h1:VNDvAkf+Pak7PHzTEZwC4OrRFyFw3hZdwC929ii3QUo=
-github.com/maas/gomaasclient v0.0.0-20230912053103-eb0ecc7ab134/go.mod h1:5h+4XHQSjnLJodlDLCxiR7m/IlGcQ15bM3Q35uxB4kA=
+github.com/maas/gomaasclient v0.0.0-20230927145110-b2775d1ca870 h1:CZ2i4fEX8xXOd5JBG+RhDILCQG5Cu0ZTFOL3qNg8Mns=
+github.com/maas/gomaasclient v0.0.0-20230927145110-b2775d1ca870/go.mod h1:6Rf68yTVxSHE35pGymgAXdZQPja2lvX3mRRHHuqdr2M=
 github.com/masterzen/azure-sdk-for-go v3.2.0-beta.0.20161014135628-ee4f0065d00c+incompatible/go.mod h1:mf8fjOu33zCqxUjuiU3I8S1lJMyEAlH+0F2+M5xl3hE=
 github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=
 github.com/masterzen/winrm v0.0.0-20161014151040-7a535cd943fc/go.mod h1:CfZSN7zwz5gJiFhZJz49Uzk7mEBHIceWmbFmYx7Hf7E=


### PR DESCRIPTION
This PR includes changes to gomaasclient, implemented on https://github.com/maas/gomaasclient/pull/14