### PR TITLE
ci: fix gofmt params, so it scans all files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ lint: lint-go
 
 .PHONY: lint-go
 lint-go:
-	@test -z "$$(gofmt -l -d *.go | tee /dev/stderr)"
+	@test -z "$$(gofmt -l -s -d . | tee /dev/stderr)"
 
 test:
 	go test $(TEST) -v $(TESTARGS) -timeout=5m -parallel=$(TEST_PARALLELISM)


### PR DESCRIPTION
```
❯ gofmt --help
usage: gofmt [flags] [path ...]
  -cpuprofile string
        write cpu profile to this file
  -d    display diffs instead of rewriting files
  -e    report all errors (not just the first 10 on different lines)
  -l    list files whose formatting differs from gofmt's
  -r string
        rewrite rule (e.g., 'a[b:len(a)] -> a[b:]')
  -s    simplify code
  -w    write result to (source) file instead of stdout
```