### PR TITLE
all: drop support of Terraform EOL versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,9 +77,9 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - '1.0.*'
-          - '1.1.*'
-          - '1.2.*'
+          - '1.4.*'
+          - '1.5.*'
+          - '1.6.*'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the source code for the Terraform MAAS provider.
 
 ## Requirements
 
-- [Terraform](https://www.terraform.io/downloads.html) >= 0.13.x
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.4.x
 - [Go](https://golang.org/doc/install) >= 1.20
 
 ## Build The Provider


### PR DESCRIPTION
1.4 is also EOL, however it is still widely used.

https://support.hashicorp.com/hc/en-us/articles/360021185113