### PR TITLE
Deploy a machine based on its `system_id`

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -65,6 +65,7 @@ Optional:
 - `min_cpu_count` (Number) The minimum number of cores used to allocate the MAAS machine.
 - `min_memory` (Number) The minimum RAM memory size (in MB) used to allocate the MAAS machine.
 - `pool` (String) The pool name of the MAAS machine to be allocated.
+- `system_id` (String) The system_id of the MAAS machine to be allocated.
 - `tags` (Set of String) A set of tag names that must be assigned on the MAAS machine to be allocated.
 - `zone` (String) The zone name of the MAAS machine to be allocated.
 

--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -68,6 +68,12 @@ func resourceMaasInstance() *schema.Resource {
 							ForceNew:    true,
 							Description: "The pool name of the MAAS machine to be allocated.",
 						},
+						"system_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: "The system_id of the MAAS machine to be allocated.",
+						},
 						"tags": {
 							Type:        schema.TypeSet,
 							Optional:    true,
@@ -296,6 +302,7 @@ func getMachinesAllocateParams(d *schema.ResourceData) *entity.MachineAllocatePa
 				Name:     allocateParams["hostname"].(string),
 				Zone:     allocateParams["zone"].(string),
 				Pool:     allocateParams["pool"].(string),
+				SystemID: allocateParams["system_id"].(string),
 				Tags:     convertToStringSlice(allocateParams["tags"].(*schema.Set).List()),
 			}
 		}


### PR DESCRIPTION
Add system_id as an optional allocate parameter. If provided, the maas_instance will try to deploy a machine with the given `system_id`.

Resolves: #113 