### PR TITLE
feat: add configurable create timeout for VM hosts

### DIFF
--- a/docs/resources/vm_host.md
+++ b/docs/resources/vm_host.md
@@ -43,6 +43,7 @@ resource "maas_vm_host" "kvm" {
 - `power_pass` (String, Sensitive) User password to use for power control of the VM host. Cannot be set if `machine` parameter is used.
 - `power_user` (String) User name to use for power control of the VM host. Cannot be set if `machine` parameter is used.
 - `tags` (Set of String) A set of tag names to assign to the new VM host. This is computed if it's not set.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) The new VM host zone name. This is computed if it's not set.
 
 ### Read-Only
@@ -51,6 +52,13 @@ resource "maas_vm_host" "kvm" {
 - `resources_cores_total` (Number) The VM host total number of CPU cores.
 - `resources_local_storage_total` (Number) The VM host total local storage (in bytes).
 - `resources_memory_total` (Number) The VM host total RAM memory (in MB).
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
 
 ## Import
 

--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -205,7 +205,7 @@ func resourceMaasInstance() *schema.Resource {
 			},
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(40 * time.Minute),
+			Create: schema.DefaultTimeout(20 * time.Minute),
 		},
 	}
 }

--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -205,7 +205,7 @@ func resourceMaasInstance() *schema.Resource {
 			},
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
+			Create: schema.DefaultTimeout(40 * time.Minute),
 		},
 	}
 }

--- a/maas/resource_maas_vm_host.go
+++ b/maas/resource_maas_vm_host.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/maas/resource_maas_vm_host.go
+++ b/maas/resource_maas_vm_host.go
@@ -158,6 +158,9 @@ func resourceMaasVMHost() *schema.Resource {
 				Description: "The new VM host zone name. This is computed if it's not set.",
 			},
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
 	}
 }
 


### PR DESCRIPTION
VM Host operations can take longer than the alloted 20 minutes, this should introduce a user configurable `timeouts` block to increase that time if needed.