### PR TITLE
fix: manage existing physical interfaces from commissioning

### DIFF
--- a/docs/resources/machine.md
+++ b/docs/resources/machine.md
@@ -45,6 +45,7 @@ resource "maas_machine" "virsh_vm1" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `network_interfaces` (Set of String) A set of MAC addresses of network interfaces attached to the machine.
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/maas/resource_maas_machine.go
+++ b/maas/resource_maas_machine.go
@@ -85,6 +85,14 @@ func resourceMaasMachine() *schema.Resource {
 				Computed:    true,
 				Description: "The minimum kernel version allowed to run on this machine. Only used when deploying Ubuntu. This is computed if it's not set.",
 			},
+			"network_interfaces": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "A set of MAC addresses of network interfaces attached to the machine.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"pool": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -188,6 +196,14 @@ func resourceMachineRead(ctx context.Context, d *schema.ResourceData, meta inter
 		"pool":           machine.Pool.Name,
 	}
 	if err := setTerraformState(d, tfState); err != nil {
+		return diag.FromErr(err)
+	}
+
+	networkInterfaces := make([]string, len(machine.InterfaceSet))
+	for i, networkInterface := range machine.InterfaceSet {
+		networkInterfaces[i] = networkInterface.MACAddress
+	}
+	if err := d.Set("network_interfaces", networkInterfaces); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
This PR includes the following changes:

- add `network_interfaces` calculated field on `maas_machine`. The field includes a set of MAC addresses of discovered interfaces during commissioning.
- change logic of `maas_network_interface_physical` when another interface is found with the same MAC address  during creation. From now on, an update operation is tried instead of no op.
- improve the logic of create, update actions. Since MAAS API is returning the created/updated object there is no need to call read action before returning. By using this improvement, we avoid running the expensive operations of `client.Machines.Get` and `client.NetworkInterface.Get`.
- make `vlan` field of `maas_network_interface_physical` "computable". Interfaces detected during commissioning already belong to a VLAN and this should be detected during the Terraform resource creation. Otherwise, idempotency is broken.

This PR fixes #165 