### PR TITLE
fix: randomize logical volume name to avoid acceptance test resource collision

### DIFF
--- a/maas/resource_maas_logical_volume_test.go
+++ b/maas/resource_maas_logical_volume_test.go
@@ -66,6 +66,7 @@ func TestAccResourceMAASLogicalVolume_formatAndMount(t *testing.T) {
 	blockDevice1Name := acctest.RandomWithPrefix("tf-lv-bd")
 	blockDevice2Name := acctest.RandomWithPrefix("tf-lv-bd")
 	volumeGroupName := acctest.RandomWithPrefix("tf-lv-vg")
+	logicalVolumeName := acctest.RandomWithPrefix("tf-lv")
 
 	// Test 1: `fs_type` not specified
 	test1FsType := ""
@@ -83,15 +84,15 @@ func TestAccResourceMAASLogicalVolume_formatAndMount(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test 1: `fs_type` not specified
 			{
-				Config:      testAccLogicalVolume(blockDevice1Name, blockDevice2Name, volumeGroupName, machine, test1FsType, "LVM test", 5, test1MountPoint),
+				Config:      testAccLogicalVolume(blockDevice1Name, blockDevice2Name, volumeGroupName, machine, test1FsType, logicalVolumeName, 5, test1MountPoint),
 				ExpectError: regexp.MustCompile(`invalid block device mount configuration: fs_type must be specified when mount_point is set`),
 			},
 			// Test 2: `mount_point` not specified
 			{
-				Config: testAccLogicalVolume(blockDevice1Name, blockDevice2Name, volumeGroupName, machine, test2FsType, "LVM test", 5, test2MountPoint),
+				Config: testAccLogicalVolume(blockDevice1Name, blockDevice2Name, volumeGroupName, machine, test2FsType, logicalVolumeName, 5, test2MountPoint),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLogicalVolumeExists("maas_logical_volume.test"),
-					resource.TestCheckResourceAttr("maas_logical_volume.test", "name", "LVM test"),
+					resource.TestCheckResourceAttr("maas_logical_volume.test", "name", logicalVolumeName),
 					resource.TestCheckResourceAttr("maas_logical_volume.test", "fs_type", test2FsType),
 					resource.TestCheckResourceAttr("maas_logical_volume.test", "mount_point", test2MountPoint),
 				),


### PR DESCRIPTION
## Description of changes

Fix the format and mount test so that it is not competing for the same logical volume object as the basic test

## Issue or ticket link (if applicable)

N/A
<!--
Please link the issue this PR addresses using GitHub’s keywords to automatically close related issues. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

e.g. Resolves: #XXX -->

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
