### PR TITLE
fix: Add second VLAN update API call to workaround MAAS bug

### DIFF
--- a/maas/resource_maas_vlan_dhcp.go
+++ b/maas/resource_maas_vlan_dhcp.go
@@ -224,8 +224,6 @@ func getVLANDHCPParams(d *schema.ResourceData) *entity.VLANParams {
 		vlanParams.RelayVLAN = &relayVLAN
 	}
 
-	fmt.Printf("%#v\n", vlanParams)
-
 	return &vlanParams
 }
 


### PR DESCRIPTION
## Description of changes

MAAS will reassign the primary to be the secondary controller when attempting to delete both. As a workaround, we remove/reset the secondary rack controller, then proceed to remove/reset the VLAN, and this works.

Raised bug here: https://bugs.launchpad.net/maas/+bug/2139359

### QA Steps

- Create two LXC containers, connected to the same NIC device - one will be treated as the primary (named "maas-primary"), the other secondary (call it "maas-secondary")
- Install MAAS 3.7/stable snap on both
- Install maas-test-db 3.7/stable snap on the elected "primary"
- Initialise primary as region+rack
- Initialise secondary as rack, using command from Controllers > Add Rack Controller info panel
- For all VLANs, disable DHCP
- Save the following Terraform plan

```terraform
provider "maas" {
  api_version         = "2.0"
  api_key             =  <MAAS_API_KEY>
  api_url             =  <MAAS_API_URL>
  installation_method = "snap"
}

variable "rack_ctrl1" {
  description = "The hostname of the first MAAS rack controller to enable DHCP on"
  type        = string
  default     = "maas-primary"
}

variable "rack_ctrl2" {
  description = "The hostname of the second MAAS rack controller to enable DHCP on for HA"
  type        = string
  default     = "maas-secondary"
}

variable "pxe_subnet" {
  description = "The subnet for the PXE server"
  type        = string
  default     = "10.10.0.0/24"
}

data "maas_rack_controller" "dhcp_rack1" {
  hostname = var.rack_ctrl1
}

data "maas_rack_controller" "dhcp_rack2" {
  hostname = var.rack_ctrl2
}

data "maas_subnet" "oam-core_subnet" {
  cidr = var.pxe_subnet
}

data "maas_fabric" "microcloud-oam" {
  name = data.maas_subnet.oam-core_subnet.fabric
}

resource "maas_subnet_ip_range" "oam-core_dhcp_range" {
  subnet   = data.maas_subnet.oam-core_subnet.id
  type     = "dynamic"
  start_ip = cidrhost(data.maas_subnet.oam-core_subnet.cidr, 150)
  end_ip   = cidrhost(data.maas_subnet.oam-core_subnet.cidr, 254)
}

resource "maas_vlan_dhcp" "oam-core_dhcp" {
  fabric                    = data.maas_fabric.microcloud-oam.id
  vlan                      = data.maas_subnet.oam-core_subnet.vid
  primary_rack_controller   = data.maas_rack_controller.dhcp_rack1.id
  secondary_rack_controller = data.maas_rack_controller.dhcp_rack2.id
  ip_ranges                 = [maas_subnet_ip_range.oam-core_dhcp_range.id]
}
```
- Execute `terraform init`, `terraform apply`, `terraform destroy`, `terraform apply`
- See that the VLAN DHCP was configured, destroyed, then configured again without the error presented in https://github.com/canonical/terraform-provider-maas/issues/376

## Issue or ticket link (if applicable)

Resolves https://github.com/canonical/terraform-provider-maas/issues/376

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
