### PR TITLE
ci: fix acceptance tests flakiness

### DIFF
--- a/maas/data_source_maas_boot_source_selection_test.go
+++ b/maas/data_source_maas_boot_source_selection_test.go
@@ -25,7 +25,7 @@ func TestAccDataSourceMAASBootSourceSelection_basic(t *testing.T) {
 		resource.TestCheckResourceAttr("maas_boot_source_selection.test", "labels.0", "*"),
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, nil) },
 		Providers:    testutils.TestAccProviders,
 		CheckDestroy: testAccCheckMAASBootSourceSelectionDestroy,

--- a/maas/resource_maas_block_device_test.go
+++ b/maas/resource_maas_block_device_test.go
@@ -110,7 +110,7 @@ func TestAccResourceMAASBlockDevice_basic(t *testing.T) {
 		resource.TestCheckResourceAttrPair("maas_block_device.test", "machine", "data.maas_machine.machine", "id"),
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
 		Providers:    testutils.TestAccProviders,
 		ErrorCheck:   func(err error) error { return err },

--- a/maas/resource_maas_boot_source_selection_test.go
+++ b/maas/resource_maas_boot_source_selection_test.go
@@ -33,7 +33,7 @@ func TestAccResourceMAASBootSourceSelection_basic(t *testing.T) {
 		resource.TestCheckResourceAttr("maas_boot_source_selection.test", "labels.0", "*"),
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, nil) },
 		Providers:    testutils.TestAccProviders,
 		CheckDestroy: testAccCheckMAASBootSourceSelectionDestroy,
@@ -85,7 +85,7 @@ func TestAccResourceMAASBootSourceSelection_basic(t *testing.T) {
 func TestAccResourceMAASBootSourceSelection_defaultCommissioningAdoption(t *testing.T) {
 	var bootSourceSelection entity.BootSourceSelection
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, nil) },
 		Providers:    testutils.TestAccProviders,
 		CheckDestroy: testAccCheckMAASBootSourceSelectionDefaultStillExists,

--- a/maas/resource_maas_logical_volume_test.go
+++ b/maas/resource_maas_logical_volume_test.go
@@ -31,7 +31,7 @@ func TestAccResourceMAASLogicalVolume_basic(t *testing.T) {
 	changedMountPoint := "/var/changed"
 	changedSize := 2
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
 		Providers:    testutils.TestAccProviders,
 		ErrorCheck:   func(err error) error { return err },
@@ -76,7 +76,7 @@ func TestAccResourceMAASLogicalVolume_formatAndMount(t *testing.T) {
 	test2FsType := "fat32"
 	test2MountPoint := ""
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
 		Providers:    testutils.TestAccProviders,
 		ErrorCheck:   func(err error) error { return err },

--- a/maas/resource_maas_machine_test.go
+++ b/maas/resource_maas_machine_test.go
@@ -52,8 +52,8 @@ resource "maas_network_interface_physical" "test_nic2" {
 // can be resolved correctly using both its system_id and its hostname.
 // The machine hostname is supplied via TF_ACC_MACHINE_HOSTNAME.
 func TestAccResourceMAASMachine_Lookup(t *testing.T) {
-	nicName1 := fmt.Sprintf("tf-nic-lookup-%d", acctest.RandIntRange(0, 9))
-	nicName2 := fmt.Sprintf("tf-nic-lookup-2-%d", acctest.RandIntRange(0, 9))
+	nicName1 := fmt.Sprintf("tf-lookup-1-%d", acctest.RandIntRange(0, 9))
+	nicName2 := fmt.Sprintf("tf-lookup-2-%d", acctest.RandIntRange(0, 9))
 	hostname := os.Getenv("TF_ACC_MACHINE_HOSTNAME")
 	macAddress1 := testutils.RandomMAC()
 	macAddress2 := testutils.RandomMAC()

--- a/maas/resource_maas_raid_test.go
+++ b/maas/resource_maas_raid_test.go
@@ -48,7 +48,7 @@ func TestAccResourceMAASRAID_basic(t *testing.T) {
 		testAccRAIDBlockDevice(blockDevice3Name, 2, false) +
 		testAccRAIDPartition(blockDevice4Name, 2, false)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
 		Providers:    testutils.TestAccProviders,
 		CheckDestroy: testAccCheclMAASRAIDDestroy,
@@ -162,7 +162,7 @@ func TestAccResourceMAASRAID_formatAndMount(t *testing.T) {
 		testAccRAIDBlockDevice(blockDevice3Name, 2, false) +
 		testAccRAIDPartition(blockDevice4Name, 2, false)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
 		Providers:    testutils.TestAccProviders,
 		CheckDestroy: testAccCheclMAASRAIDDestroy,
@@ -222,7 +222,7 @@ func TestAccResourceMAASRAID_differentLevels(t *testing.T) {
 			blockDevice3Name := fmt.Sprintf("raid_level_%s_test_bd3", thisLevel)
 			blockDevice4Name := fmt.Sprintf("raid_level_%s_test_bd4", thisLevel)
 
-			resource.ParallelTest(t, resource.TestCase{
+			resource.Test(t, resource.TestCase{
 				PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
 				Providers:    testutils.TestAccProviders,
 				CheckDestroy: testAccCheclMAASRAIDDestroy,

--- a/maas/resource_maas_volume_group_test.go
+++ b/maas/resource_maas_volume_group_test.go
@@ -26,7 +26,7 @@ func TestAccResourceMAASVolumeGroup_basic(t *testing.T) {
 		resource.TestCheckResourceAttrPair("maas_volume_group.test", "machine", "data.maas_machine.machine", "id"),
 	}
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
 		Providers:    testutils.TestAccProviders,
 		CheckDestroy: testAccCheckMAASVolumeGroupDestroy,


### PR DESCRIPTION
## Description of changes

<!-- A clear and concise description of your changes here. -->
- Disabled parallel execution of boot source selection tests to prevent race conditions during concurrent MAAS boot resource imports
- Disabled parallel execution of block device-related tests (block device, logical volume, RAID, volume group) to prevent race conditions when multiple tests compete to create/manage the boot block device of the same machine
- Shortened NIC names in TestAccResourceMAASMachine_Lookup from tf-nic-lookup-* to tf-lookup-* to comply with kernel's 15-character limit for interface names. This is not causing flakiness but allows the tests to run on MAAS 3.7 where MAAS added a validation to the interface name.

## Issue or ticket link (if applicable)

N/A
<!--
Please link the issue this PR addresses using GitHub’s keywords to automatically close related issues. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

e.g. Resolves: #XXX -->

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
