### PR TITLE
fix: Handle disconnection/deletion of physical network interface and links when machine not in "valid" state

### DIFF
--- a/maas/resource_maas_fabric.go
+++ b/maas/resource_maas_fabric.go
@@ -57,7 +57,7 @@ func resourceFabricCreate(ctx context.Context, d *schema.ResourceData, meta any)
 
 	d.SetId(fmt.Sprintf("%v", fabric.ID))
 
-	return resourceFabricUpdate(ctx, d, meta)
+	return resourceFabricRead(ctx, d, meta)
 }
 
 func resourceFabricRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/maas/resource_maas_fabric.go
+++ b/maas/resource_maas_fabric.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/canonical/gomaasclient/client"
 	"github.com/canonical/gomaasclient/entity"
@@ -100,12 +99,6 @@ func resourceFabricDelete(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	if err := client.Fabric.Delete(id); err != nil {
-		// fabrics with nothing attached can be automatically cleaned up by MAAS,
-		// we shouldn't error if the fabric is missing
-		if strings.Contains(err.Error(), "404 Not Found") {
-			return nil
-		}
-
 		return diag.FromErr(err)
 	}
 

--- a/maas/resource_maas_fabric.go
+++ b/maas/resource_maas_fabric.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/canonical/gomaasclient/client"
 	"github.com/canonical/gomaasclient/entity"
@@ -69,7 +70,7 @@ func resourceFabricRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	}
 
 	if _, err := client.Fabric.Get(id); err != nil {
-		return diag.FromErr(err)
+		return unsetIfNotFoundError(d, err)
 	}
 
 	return nil
@@ -99,6 +100,12 @@ func resourceFabricDelete(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	if err := client.Fabric.Delete(id); err != nil {
+		// fabrics with nothing attached can be automatically cleaned up by MAAS,
+		// we shouldn't error if the fabric is missing
+		if strings.Contains(err.Error(), "404 Not Found") {
+			return nil
+		}
+
 		return diag.FromErr(err)
 	}
 

--- a/maas/resource_maas_network_interface_bond_test.go
+++ b/maas/resource_maas_network_interface_bond_test.go
@@ -30,11 +30,26 @@ data "maas_vlan" "default" {
 	vlan   = 0
 }
 
+resource "maas_subnet" "test_subnet" {
+	fabric       = maas_fabric.default.id
+	vlan         = data.maas_vlan.default.id
+	cidr         = "%s"
+}
+
 resource "maas_network_interface_physical" "nic1" {
 	machine     = data.maas_machine.machine.id
 	mac_address = "%s"
 	name        = "enp109s0f0"
 	vlan        = data.maas_vlan.default.id
+
+	# When a physical interface is disconnected from a VLAN, MAAS automatically deletes the fabric
+	# if the VLAN has no other interfaces or subnets attached. To prevent the fabric from being
+	# deleted before the interface is disconnected, we add an explicit dependency on the subnet.
+	# This ensures the subnet (and thus the fabric) remains until after the interface is
+	# disconnected, allowing us to verify the disconnection without the fabric being removed
+	# prematurely.
+	# https://github.com/canonical/maas/commit/885021185340f740355faf13ad17b8fde5d8d285
+	depends_on = [maas_subnet.test_subnet]
 }
 
 resource "maas_network_interface_physical" "nic2" {
@@ -42,6 +57,15 @@ resource "maas_network_interface_physical" "nic2" {
 	mac_address = "%s"
 	name        = "enp109s0f1"
 	vlan        = data.maas_vlan.default.id
+
+	# When a physical interface is disconnected from a VLAN, MAAS automatically deletes the fabric
+	# if the VLAN has no other interfaces or subnets attached. To prevent the fabric from being
+	# deleted before the interface is disconnected, we add an explicit dependency on the subnet.
+	# This ensures the subnet (and thus the fabric) remains until after the interface is
+	# disconnected, allowing us to verify the disconnection without the fabric being removed
+	# prematurely.
+	# https://github.com/canonical/maas/commit/885021185340f740355faf13ad17b8fde5d8d285
+	depends_on = [maas_subnet.test_subnet]
 }
 
 resource "maas_network_interface_bond" "test" {
@@ -61,7 +85,7 @@ resource "maas_network_interface_bond" "test" {
 	tags                  = ["tag1", "tag2"]
 	vlan                  = data.maas_vlan.default.id
 }
-`, machine, macAddressPhysOne, macAddressPhysTwo, name, macAddress, mtu)
+`, machine, testutils.GenerateRandomCIDR(), macAddressPhysOne, macAddressPhysTwo, name, macAddress, mtu)
 }
 
 func TestAccResourceMAASNetworkInterfaceBond_basic(t *testing.T) {

--- a/maas/resource_maas_network_interface_bridge_test.go
+++ b/maas/resource_maas_network_interface_bridge_test.go
@@ -30,11 +30,26 @@ data "maas_vlan" "default" {
 	vlan   = 0
 }
 
+resource "maas_subnet" "test_subnet" {
+	fabric       = maas_fabric.default.id
+	vlan         = data.maas_vlan.default.id
+	cidr         = "%s"
+}
+
 resource "maas_network_interface_physical" "nic1" {
 	machine     = data.maas_machine.machine.id
 	mac_address = "%s"
 	name        = "ethbr"
 	vlan        = data.maas_vlan.default.id
+
+	# When a physical interface is disconnected from a VLAN, MAAS automatically deletes the fabric
+	# if the VLAN has no other interfaces or subnets attached. To prevent the fabric from being
+	# deleted before the interface is disconnected, we add an explicit dependency on the subnet.
+	# This ensures the subnet (and thus the fabric) remains until after the interface is
+	# disconnected, allowing us to verify the disconnection without the fabric being removed
+	# prematurely.
+	# https://github.com/canonical/maas/commit/885021185340f740355faf13ad17b8fde5d8d285
+	depends_on = [maas_subnet.test_subnet]
 }
 
 resource "maas_network_interface_bridge" "test" {
@@ -50,7 +65,7 @@ resource "maas_network_interface_bridge" "test" {
 	tags        = ["tag1", "tag2"]
 	vlan        = data.maas_vlan.default.id
   }
-`, machine, macAddressPhys, name, macAddress, mtu)
+`, machine, testutils.GenerateRandomCIDR(), macAddressPhys, name, macAddress, mtu)
 }
 
 func TestAccResourceMAASNetworkInterfaceBridge_basic(t *testing.T) {

--- a/maas/resource_maas_network_interface_link.go
+++ b/maas/resource_maas_network_interface_link.go
@@ -112,18 +112,18 @@ func resourceNetworkInterfaceLinkRead(ctx context.Context, d *schema.ResourceDat
 
 	systemID, err := getMachineOrDeviceSystemID(client, d)
 	if err != nil {
-		return diag.FromErr(err)
+		return unsetIfNotFoundError(d, err)
 	}
 
 	networkInterface, err := getNetworkInterface(client, systemID, d.Get("network_interface").(string))
 	if err != nil {
-		return diag.FromErr(err)
+		return unsetIfNotFoundError(d, err)
 	}
 
 	// Get the network interface link
-	link, err := getNetworkInterfaceLink(client, systemID, networkInterface.ID, linkID)
+	link, err := getNetworkInterfaceLink(client, networkInterface, linkID)
 	if err != nil {
-		return diag.FromErr(err)
+		return unsetIfNotFoundError(d, err)
 	}
 
 	// Set the Terraform state
@@ -143,17 +143,25 @@ func resourceNetworkInterfaceLinkUpdate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	systemID, err := getMachineOrDeviceSystemID(client, d)
+	// Update only happens when default_gateway changes (the only non-ForceNew field).
+	// Since default_gateway has ConflictsWith device, we know this must be a machine.
+	machine, err := getMachine(client, d.Get("machine").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	if !isMachineInPermittedState(machine) {
+		return diag.Errorf("machine is not in a permitted state for update")
+	}
+
+	systemID := machine.SystemID
 
 	networkInterface, err := getNetworkInterface(client, systemID, d.Get("network_interface").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Run update operation
+	// Clear existing default gateways before potentially setting a new one
 	if _, err := client.Machine.ClearDefaultGateways(systemID); err != nil {
 		return diag.FromErr(err)
 	}
@@ -221,19 +229,14 @@ func createNetworkInterfaceLink(client *client.Client, machineSystemID string, n
 	return &networkInterface.Links[0], nil
 }
 
-func getNetworkInterfaceLink(client *client.Client, machineSystemID string, networkInterfaceID int, linkID int) (*entity.NetworkInterfaceLink, error) {
-	networkInterface, err := client.NetworkInterface.Get(machineSystemID, networkInterfaceID)
-	if err != nil {
-		return nil, err
-	}
-
+func getNetworkInterfaceLink(client *client.Client, networkInterface *entity.NetworkInterface, linkID int) (*entity.NetworkInterfaceLink, error) {
 	for _, link := range networkInterface.Links {
 		if link.ID == linkID {
 			return &link, nil
 		}
 	}
 
-	return nil, fmt.Errorf("cannot find link (%v) on the network interface (%v) from machine (%s)", linkID, networkInterfaceID, machineSystemID)
+	return nil, fmt.Errorf("cannot find link (%v) on the network interface (%v) from machine (%s)", linkID, networkInterface.ID, networkInterface.SystemID)
 }
 
 func deleteNetworkInterfaceLink(client *client.Client, machineSystemID string, networkInterfaceID int, linkID int) error {

--- a/maas/resource_maas_network_interface_link_test.go
+++ b/maas/resource_maas_network_interface_link_test.go
@@ -38,6 +38,15 @@ resource "maas_network_interface_physical" "test" {
   mac_address = "%s"
   name        = "tf0"
   vlan        = data.maas_vlan.default.id
+
+  # When a physical interface is disconnected from a VLAN, MAAS automatically deletes the fabric
+  # if the VLAN has no other interfaces or subnets attached. To prevent the fabric from being
+  # deleted before the interface is disconnected, we add an explicit dependency on the subnet.
+  # This ensures the subnet (and thus the fabric) remains until after the interface is
+  # disconnected, allowing us to verify the disconnection without the fabric being removed
+  # prematurely.
+  # https://github.com/canonical/maas/commit/885021185340f740355faf13ad17b8fde5d8d285
+  depends_on = [maas_subnet.test]
 }
 
 resource "maas_network_interface_vlan" "test" {

--- a/maas/resource_maas_network_interface_physical.go
+++ b/maas/resource_maas_network_interface_physical.go
@@ -133,7 +133,7 @@ func resourceNetworkInterfacePhysicalRead(ctx context.Context, d *schema.Resourc
 
 	machine, err := getMachine(client, d.Get("machine").(string))
 	if err != nil {
-		return diag.FromErr(err)
+		return unsetIfNotFoundError(d, err)
 	}
 
 	id, err := strconv.Atoi(d.Id())
@@ -143,7 +143,7 @@ func resourceNetworkInterfacePhysicalRead(ctx context.Context, d *schema.Resourc
 
 	networkInterface, err := client.NetworkInterface.Get(machine.SystemID, id)
 	if err != nil {
-		return diag.FromErr(err)
+		return unsetIfNotFoundError(d, err)
 	}
 
 	tfState := map[string]any{
@@ -205,7 +205,7 @@ func resourceNetworkInterfacePhysicalDelete(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 
-	if err := client.NetworkInterface.Delete(machine.SystemID, id); err != nil {
+	if _, err := client.NetworkInterface.Disconnect(machine.SystemID, id); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/maas/resource_maas_network_interface_physical_test.go
+++ b/maas/resource_maas_network_interface_physical_test.go
@@ -31,9 +31,9 @@ data "maas_vlan" "default" {
 }
 
 resource "maas_subnet" "test_subnet" {
-	fabric       = maas_fabric.default.id
-	vlan         = data.maas_vlan.default.id
-	cidr         = "%s"
+    fabric       = maas_fabric.default.id
+    vlan         = data.maas_vlan.default.id
+    cidr         = "%s"
 }
 
 resource "maas_network_interface_physical" "test" {
@@ -44,13 +44,13 @@ resource "maas_network_interface_physical" "test" {
     tags        = ["tag1", "tag2"]
     vlan        = data.maas_vlan.default.id
 
-	# When a physical interface is disconnected from a VLAN, MAAS automatically deletes the fabric
-	# if the VLAN has no other interfaces or subnets attached. To prevent the fabric from being
-	# deleted before the interface is disconnected, we add an explicit dependency on the subnet.
-	# This ensures the subnet (and thus the fabric) remains until after the interface is
-	# disconnected, allowing us to verify the disconnection without the fabric being removed
-	# prematurely.
-	# https://github.com/canonical/maas/commit/885021185340f740355faf13ad17b8fde5d8d285
+    # When a physical interface is disconnected from a VLAN, MAAS automatically deletes the fabric
+    # if the VLAN has no other interfaces or subnets attached. To prevent the fabric from being
+    # deleted before the interface is disconnected, we add an explicit dependency on the subnet.
+    # This ensures the subnet (and thus the fabric) remains until after the interface is
+    # disconnected, allowing us to verify the disconnection without the fabric being removed
+    # prematurely.
+    # https://github.com/canonical/maas/commit/885021185340f740355faf13ad17b8fde5d8d285
     depends_on = [maas_subnet.test_subnet]
   }
 `, fabricName, machine, testutils.GenerateRandomCIDR(), name, macAddress, mtu)

--- a/maas/resource_maas_network_interface_physical_test.go
+++ b/maas/resource_maas_network_interface_physical_test.go
@@ -30,6 +30,12 @@ data "maas_vlan" "default" {
     vlan   = 0
 }
 
+resource "maas_subnet" "test_subnet" {
+	fabric       = maas_fabric.default.id
+	vlan         = data.maas_vlan.default.id
+	cidr         = "%s"
+}
+
 resource "maas_network_interface_physical" "test" {
     machine     = data.maas_machine.machine.id
     name        = "%s"
@@ -37,8 +43,17 @@ resource "maas_network_interface_physical" "test" {
     mtu         = %d
     tags        = ["tag1", "tag2"]
     vlan        = data.maas_vlan.default.id
+
+	# When a physical interface is disconnected from a VLAN, MAAS automatically deletes the fabric
+	# if the VLAN has no other interfaces or subnets attached. To prevent the fabric from being
+	# deleted before the interface is disconnected, we add an explicit dependency on the subnet.
+	# This ensures the subnet (and thus the fabric) remains until after the interface is
+	# disconnected, allowing us to verify the disconnection without the fabric being removed
+	# prematurely.
+	# https://github.com/canonical/maas/commit/885021185340f740355faf13ad17b8fde5d8d285
+    depends_on = [maas_subnet.test_subnet]
   }
-`, fabricName, machine, name, macAddress, mtu)
+`, fabricName, machine, testutils.GenerateRandomCIDR(), name, macAddress, mtu)
 }
 
 func TestAccResourceMAASNetworkInterfacePhysical_basic(t *testing.T) {

--- a/maas/resource_maas_network_interface_physical_test.go
+++ b/maas/resource_maas_network_interface_physical_test.go
@@ -163,11 +163,15 @@ func testAccCheckMAASNetworkInterfacePhysicalDestroy(s *terraform.State) error {
 
 		response, err := conn.NetworkInterface.Get(rs.Primary.Attributes["machine"], id)
 		if err == nil {
-			if response != nil && response.ID == id {
-				return fmt.Errorf("MAAS Network interface physical (%s) still exists.", rs.Primary.ID)
+			// because this device is physical, we need to check it was *disconnected*, not destroyed
+			if response != nil && response.VLAN.ID != 0 {
+				return fmt.Errorf("MAAS Network interface physical (%s) still exists and is not disconnected from VLAN (%d)", rs.Primary.ID, response.VLAN.ID)
 			}
 
-			return nil
+			// we also need to clean up the dummy mac addresses that are created
+			_ = conn.NetworkInterface.Delete(rs.Primary.Attributes["machine"], id)
+
+			continue
 		}
 
 		// If the error is equivalent to 404 not found, the maas_network_interface_physical is destroyed.

--- a/maas/resource_maas_network_interface_physical_test.go
+++ b/maas/resource_maas_network_interface_physical_test.go
@@ -15,36 +15,39 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func testAccMAASNetworkInterfacePhysical(name string, machine string, macAddress string, mtu int) string {
+func testAccMAASNetworkInterfacePhysical(fabricName string, name string, machine string, macAddress string, mtu int) string {
 	return fmt.Sprintf(`
 resource "maas_fabric" "default" {
-	name = "tf-fabric-physical"
+    name = "%s"
 }
 
 data "maas_machine" "machine" {
-	hostname = "%s"
+    hostname = "%s"
 }
 
 data "maas_vlan" "default" {
-	fabric = maas_fabric.default.id
-	vlan   = 0
+    fabric = maas_fabric.default.id
+    vlan   = 0
 }
 
 resource "maas_network_interface_physical" "test" {
-	machine     = data.maas_machine.machine.id
-	name        = "%s"
-	mac_address = "%s"
-	mtu         = %d
-	tags        = ["tag1", "tag2"]
-	vlan        = data.maas_vlan.default.id
+    machine     = data.maas_machine.machine.id
+    name        = "%s"
+    mac_address = "%s"
+    mtu         = %d
+    tags        = ["tag1", "tag2"]
+    vlan        = data.maas_vlan.default.id
   }
-`, machine, name, macAddress, mtu)
+`, fabricName, machine, name, macAddress, mtu)
 }
 
 func TestAccResourceMAASNetworkInterfacePhysical_basic(t *testing.T) {
 	var networkInterfacePhysical entity.NetworkInterface
 
-	name := fmt.Sprintf("tf-nic-eth-%d", acctest.RandIntRange(0, 9))
+	fabricName := acctest.RandomWithPrefix("tf-fab")
+
+	name := fmt.Sprintf("tf-nic-eth-%d", acctest.RandIntRange(0, 999))
+
 	machine := os.Getenv("TF_ACC_NETWORK_INTERFACE_MACHINE")
 	macAddress := testutils.RandomMAC()
 
@@ -65,13 +68,14 @@ func TestAccResourceMAASNetworkInterfacePhysical_basic(t *testing.T) {
 		ErrorCheck:   func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMAASNetworkInterfacePhysical(name, machine, macAddress, 1500),
+				// Pass the dynamic fabric name into the config generator
+				Config: testAccMAASNetworkInterfacePhysical(fabricName, name, machine, macAddress, 1500),
 				Check: resource.ComposeTestCheckFunc(
 					append(checks, resource.TestCheckResourceAttr("maas_network_interface_physical.test", "mtu", "1500"))...),
 			},
 			// Test update
 			{
-				Config: testAccMAASNetworkInterfacePhysical(name, machine, macAddress, 9000),
+				Config: testAccMAASNetworkInterfacePhysical(fabricName, name, machine, macAddress, 9000),
 				Check: resource.ComposeTestCheckFunc(
 					append(checks, resource.TestCheckResourceAttr("maas_network_interface_physical.test", "mtu", "9000"))...),
 			},
@@ -167,9 +171,6 @@ func testAccCheckMAASNetworkInterfacePhysicalDestroy(s *terraform.State) error {
 			if response != nil && response.VLAN.ID != 0 {
 				return fmt.Errorf("MAAS Network interface physical (%s) still exists and is not disconnected from VLAN (%d)", rs.Primary.ID, response.VLAN.ID)
 			}
-
-			// we also need to clean up the dummy mac addresses that are created
-			_ = conn.NetworkInterface.Delete(rs.Primary.Attributes["machine"], id)
 
 			continue
 		}

--- a/maas/resource_maas_network_interface_tag.go
+++ b/maas/resource_maas_network_interface_tag.go
@@ -136,12 +136,12 @@ func resourceNetworkInterfaceTagRead(ctx context.Context, d *schema.ResourceData
 
 	systemID, interfaceID, err := SplitTagStateID(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return unsetIfNotFoundError(d, err)
 	}
 	// Get the existing interface
 	existingInterface, err := client.NetworkInterface.Get(systemID, interfaceID)
 	if err != nil {
-		return diag.FromErr(err)
+		return unsetIfNotFoundError(d, err)
 	}
 	// Set the tags in state
 	if err := d.Set("tags", existingInterface.Tags); err != nil {

--- a/maas/resource_maas_network_interface_vlan_test.go
+++ b/maas/resource_maas_network_interface_vlan_test.go
@@ -35,11 +35,26 @@ resource "maas_vlan" "tf_vlan" {
 	name   = "tf-vlan-42"
 }
 
+resource "maas_subnet" "test_subnet" {
+	fabric       = maas_fabric.default.id
+	vlan         = data.maas_vlan.default.id
+	cidr         = "%s"
+}
+
 resource "maas_network_interface_physical" "nic1" {
 	machine     = data.maas_machine.machine.id
 	mac_address = "%s"
 	name        = "bond0"
 	vlan        = data.maas_vlan.default.id
+
+	# When a physical interface is disconnected from a VLAN, MAAS automatically deletes the fabric
+	# if the VLAN has no other interfaces or subnets attached. To prevent the fabric from being
+	# deleted before the interface is disconnected, we add an explicit dependency on the subnet.
+	# This ensures the subnet (and thus the fabric) remains until after the interface is
+	# disconnected, allowing us to verify the disconnection without the fabric being removed
+	# prematurely.
+	# https://github.com/canonical/maas/commit/885021185340f740355faf13ad17b8fde5d8d285
+	depends_on = [maas_subnet.test_subnet]
 }
 
 resource "maas_network_interface_vlan" "test" {
@@ -51,7 +66,7 @@ resource "maas_network_interface_vlan" "test" {
 	tags      = ["tag1", "tag2"]
 	vlan      = maas_vlan.tf_vlan.id
 }
-  `, machine, macAddressPhys, mtu)
+  `, machine, testutils.GenerateRandomCIDR(), macAddressPhys, mtu)
 }
 
 func TestAccResourceMAASNetworkInterfaceVLAN_basic(t *testing.T) {

--- a/maas/utils.go
+++ b/maas/utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/canonical/gomaasclient/client"
 	"github.com/canonical/gomaasclient/entity"
+	"github.com/canonical/gomaasclient/entity/node"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/go-cty/cty/gocty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -150,7 +151,7 @@ func setTerraformState(d *schema.ResourceData, tfState map[string]any) error {
 func getMachineOrDeviceSystemID(client *client.Client, d *schema.ResourceData) (string, error) {
 	if d.Get("machine") != "" {
 		machine, err := getMachine(client, d.Get("machine").(string))
-		if err != nil && !strings.Contains(err.Error(), "404 Not Found") {
+		if err != nil {
 			return "", err
 		}
 
@@ -159,7 +160,7 @@ func getMachineOrDeviceSystemID(client *client.Client, d *schema.ResourceData) (
 
 	if d.Get("device") != "" {
 		device, err := getDevice(client, d.Get("device").(string))
-		if err != nil && !strings.Contains(err.Error(), "404 Not Found") {
+		if err != nil {
 			return "", err
 		}
 
@@ -258,6 +259,9 @@ func optionalStringPtr(value string) *string {
 	return &value
 }
 
+// unsetIfNotFoundError checks if the given error is a 404 Not Found error, and if so,
+// unsets the ID of the resource data and returns no diagnostics.
+// Otherwise, it returns diagnostics containing the error.
 func unsetIfNotFoundError(d *schema.ResourceData, err error) diag.Diagnostics {
 	if strings.Contains(err.Error(), "404 Not Found") {
 		d.SetId("")
@@ -265,4 +269,19 @@ func unsetIfNotFoundError(d *schema.ResourceData, err error) diag.Diagnostics {
 	}
 
 	return diag.FromErr(err)
+}
+
+// isNotFoundError checks if the given error is a 404 Not Found error.
+func isMachineInPermittedState(machine *entity.Machine) bool {
+	switch machine.Status {
+	case
+		node.StatusNew,
+		node.StatusReady,
+		node.StatusAllocated,
+		node.StatusBroken,
+		node.StatusFailedTesting:
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
## Description of changes

Introduce the same `unsetIfNotFound` behaviour from #428 and #433, this time to physical network interfaces, network links, network interface tags, and MAAS fabrics.

network interface links require the MAAS Machine to be in one of the permited states (`new`, `ready`, `allocated`, `broken`, and `failed testing`) for update operations, so we introduce a new check and error out if not found.

In addition, physical networks are now disconnected, rather than deleted. As a result, fabric needed to have the same unset behaviour, as MAAS will automatically cleanup the empty resources [here](https://github.com/canonical/maas/blob/bab9787fa31c2a236ebe71cdb4ff369115b76f53/src/maasserver/models/signals/interfaces.py#L246), and the check destroy tests have been modified to capture the disconnect rather than delete.

## Issue or ticket link (if applicable)

Contributes to resolving the remainder of #237 

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
