### PR TITLE
feat: add `skip_bmc_config` to machine commisioning parameters

### DIFF
--- a/docs/resources/machine.md
+++ b/docs/resources/machine.md
@@ -128,6 +128,7 @@ resource "maas_machine" "ipmi_machine" {
 - `pool` (String) The resource pool of the machine. This is computed if it's not set.
 - `pxe_mac_address` (String) The MAC address of the machine's PXE boot NIC, optional for IPMI machines but required for all other power types.
 - `script_parameters` (Map of String) Scripts specified to run may define their own parameters. These parameters may be passed as parameter name (key) value pairs as a map. Optionally a parameter may have the script name prepended to have that parameter only apply to that specific script, e.g. my-script_param=value.
+- `skip_bmc_config` (Boolean) Optional parameter to skip re-configuration of the BMC for IPMI based machines
 - `testing_scripts` (List of String) Testing scripts names and tags to be run after commissioning. By default all tests tagged 'testing' will be run. Set to ['none'] to disable running tests.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) The zone of the machine. This is computed if it's not set.

--- a/maas/resource_maas_machine.go
+++ b/maas/resource_maas_machine.go
@@ -204,6 +204,11 @@ func resourceMAASMachine() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"skip_bmc_config": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Optional parameter to skip re-configuration of the BMC for IPMI based machines",
+			},
 			"testing_scripts": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -446,6 +451,7 @@ func getMachineCommissionParams(d *schema.ResourceData) *entity.MachineCommissio
 		CommissioningScripts: listAsString(d.Get("commissioning_scripts").([]any)),
 		TestingScripts:       listAsString(d.Get("testing_scripts").([]any)),
 		ScriptParams:         d.Get("script_parameters").(map[string]any),
+		SkipBMCConfig:        d.Get("skip_bmc_config").(bool),
 	}
 }
 


### PR DESCRIPTION
## Description of changes

Adds the optional `skip_bmc_config` commissioning parameter to Machine resources, which is passed only at the commissioning step of creation and update.

<!-- A clear and concise description of your changes here. -->

## Issue or ticket link (if applicable)

Resolves: #369 
<!--
Please link the issue this PR addresses using GitHub’s keywords to automatically close related issues. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

e.g. Resolves: #XXX -->

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [ ] I have added or updated the tests to reflect the changes.
- [ ] I have run the unit tests and they pass.
- [ ] I have run the acceptance tests and they pass.
