### PR TITLE
refactor: physical mac adress matches irrespective of case

### DIFF
--- a/maas/resource_maas_network_interface_physical.go
+++ b/maas/resource_maas_network_interface_physical.go
@@ -243,7 +243,7 @@ func findNetworkInterfacePhysical(client *client.Client, machineSystemID string,
 			continue
 		}
 
-		if n.MACAddress == identifier || n.Name == identifier || strconv.Itoa(n.ID) == identifier {
+		if strings.EqualFold(n.MACAddress, identifier) || n.Name == identifier || strconv.Itoa(n.ID) == identifier {
 			return &n, nil
 		}
 	}

--- a/maas/resource_maas_network_interface_physical_test.go
+++ b/maas/resource_maas_network_interface_physical_test.go
@@ -130,6 +130,58 @@ func TestAccResourceMAASNetworkInterfacePhysical_basic(t *testing.T) {
 					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["machine"], rs.Primary.Attributes["mac_address"]), nil
 				},
 			},
+			// Test import by MAC Address irrespective of case
+			{
+				ResourceName:      "maas_network_interface_physical.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["maas_network_interface_physical.test"]
+					if !ok {
+						return "", fmt.Errorf("resource not found: %s", "maas_network_interface_physical.test")
+					}
+
+					if rs.Primary.ID == "" {
+						return "", fmt.Errorf("resource id not set")
+					}
+
+					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["machine"], strings.ToUpper(rs.Primary.Attributes["mac_address"])), nil
+				},
+			},
+			{
+				ResourceName:      "maas_network_interface_physical.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["maas_network_interface_physical.test"]
+					if !ok {
+						return "", fmt.Errorf("resource not found: %s", "maas_network_interface_physical.test")
+					}
+
+					if rs.Primary.ID == "" {
+						return "", fmt.Errorf("resource id not set")
+					}
+
+					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["machine"], strings.ToLower(rs.Primary.Attributes["mac_address"])), nil
+				},
+			},
+			{
+				ResourceName:      "maas_network_interface_physical.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["maas_network_interface_physical.test"]
+					if !ok {
+						return "", fmt.Errorf("resource not found: %s", "maas_network_interface_physical.test")
+					}
+
+					if rs.Primary.ID == "" {
+						return "", fmt.Errorf("resource id not set")
+					}
+
+					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["machine"], strings.ToTitle(rs.Primary.Attributes["mac_address"])), nil
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Description of changes

Match physical interface mac address independently of case
uses the `strings.equalFold()`  function when comparing mac addresses from the MAAS api to the terraform plan

## Issue or ticket link (if applicable)

fixes: #397

<!--
Please link the issue this PR addresses using GitHub’s keywords to automatically close related issues. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

e.g. Resolves: #XXX -->

Without the changes to the search function, the test case returns:
```bash
=== CONT  TestAccResourceMAASNetworkInterfacePhysical_basic
    resource_maas_network_interface_physical_test.go:79: Step 5/7 error running import: exit status 1
        
        Error: physical network interface (7E:D1:C0:76:14:3F) was not found on machine (fnqbab)
        
        
--- FAIL: TestAccResourceMAASNetworkInterfacePhysical_basic (9.74s)
FAIL
FAIL    terraform-provider-maas/maas    9.745s
testing: warning: no tests to run
PASS
ok      terraform-provider-maas/maas/testutils  0.003s [no tests to run]
FAIL
make: *** [Makefile:61: testacc] Error 1
```

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
