### PR TITLE
feat: add id to machine block device

### DIFF
--- a/docs/resources/machine.md
+++ b/docs/resources/machine.md
@@ -153,6 +153,7 @@ Optional:
 
 Read-Only:
 
+- `id` (Number)
 - `id_path` (String)
 - `model` (String)
 - `name` (String)

--- a/docs/resources/machine.md
+++ b/docs/resources/machine.md
@@ -157,6 +157,7 @@ Read-Only:
 - `id_path` (String)
 - `model` (String)
 - `name` (String)
+- `serial` (String)
 - `size_gigabytes` (Number)
 
 ## Import

--- a/maas/resource_maas_machine.go
+++ b/maas/resource_maas_machine.go
@@ -86,6 +86,11 @@ func resourceMAASMachine() *schema.Resource {
 				Description: "A list of block devices attached to the machine.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The ID of the block device.",
+						},
 						"id_path": {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -518,6 +523,7 @@ func getAllBlockDeviceMachineParameters(blockDevices []entity.BlockDevice) []map
 	blockDeviceParams := make([]map[string]any, len(blockDevices))
 	for i, blockDevice := range blockDevices {
 		blockDeviceParams[i] = map[string]any{
+			"id":             blockDevice.ID,
 			"name":           blockDevice.Name,
 			"size_gigabytes": int(math.Round(float64(blockDevice.Size) / GigaBytes)),
 			"id_path":        blockDevice.IDPath,

--- a/maas/resource_maas_machine.go
+++ b/maas/resource_maas_machine.go
@@ -101,15 +101,15 @@ func resourceMAASMachine() *schema.Resource {
 							Computed:    true,
 							Description: "The model of the block device.",
 						},
-						"serial": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "The serial number of the block device.",
-						},
 						"name": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The block device name.",
+						},
+						"serial": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The serial number of the block device.",
 						},
 						"size_gigabytes": {
 							Type:        schema.TypeInt,

--- a/maas/resource_maas_machine.go
+++ b/maas/resource_maas_machine.go
@@ -101,6 +101,11 @@ func resourceMAASMachine() *schema.Resource {
 							Computed:    true,
 							Description: "The model of the block device.",
 						},
+						"serial": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The serial number of the block device.",
+						},
 						"name": {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -514,20 +519,26 @@ func getMachine(client *client.Client, identifier string) (*entity.Machine, erro
 }
 
 func getAllBlockDeviceMachineParameters(blockDevices []entity.BlockDevice) []map[string]any {
-	// sort block devices by ID
-	sort.Slice(blockDevices, func(i, j int) bool {
-		return blockDevices[i].ID < blockDevices[j].ID
+	var physical []entity.BlockDevice
+	for _, bd := range blockDevices {
+		if bd.Type == "physical" {
+			physical = append(physical, bd)
+		}
+	}
+
+	sort.Slice(physical, func(i, j int) bool {
+		return physical[i].ID < physical[j].ID
 	})
 
-	// Create a slice of maps to hold block device parameters
-	blockDeviceParams := make([]map[string]any, len(blockDevices))
-	for i, blockDevice := range blockDevices {
+	blockDeviceParams := make([]map[string]any, len(physical))
+	for i, blockDevice := range physical {
 		blockDeviceParams[i] = map[string]any{
 			"id":             blockDevice.ID,
 			"name":           blockDevice.Name,
 			"size_gigabytes": int(math.Round(float64(blockDevice.Size) / GigaBytes)),
 			"id_path":        blockDevice.IDPath,
 			"model":          blockDevice.Model,
+			"serial":         blockDevice.Serial,
 		}
 	}
 

--- a/maas/resource_maas_machine.go
+++ b/maas/resource_maas_machine.go
@@ -525,7 +525,7 @@ func getAllBlockDeviceMachineParameters(blockDevices []entity.BlockDevice) []map
 	})
 
 	// Create a slice of maps to hold block device parameters
-    blockDeviceParams := make([]map[string]any, len(blockDevices))
+	blockDeviceParams := make([]map[string]any, len(blockDevices))
 	for i, blockDevice := range blockDevices {
 		blockDeviceParams[i] = map[string]any{
 			"id":             blockDevice.ID,

--- a/maas/resource_maas_machine.go
+++ b/maas/resource_maas_machine.go
@@ -519,19 +519,14 @@ func getMachine(client *client.Client, identifier string) (*entity.Machine, erro
 }
 
 func getAllBlockDeviceMachineParameters(blockDevices []entity.BlockDevice) []map[string]any {
-	var physical []entity.BlockDevice
-	for _, bd := range blockDevices {
-		if bd.Type == "physical" {
-			physical = append(physical, bd)
-		}
-	}
-
-	sort.Slice(physical, func(i, j int) bool {
-		return physical[i].ID < physical[j].ID
+	// sort block devices by ID
+	sort.Slice(blockDevices, func(i, j int) bool {
+		return blockDevices[i].ID < blockDevices[j].ID
 	})
 
-	blockDeviceParams := make([]map[string]any, len(physical))
-	for i, blockDevice := range physical {
+	// Create a slice of maps to hold block device parameters
+    blockDeviceParams := make([]map[string]any, len(blockDevices))
+	for i, blockDevice := range blockDevices {
 		blockDeviceParams[i] = map[string]any{
 			"id":             blockDevice.ID,
 			"name":           blockDevice.Name,


### PR DESCRIPTION
## Description of changes

Add id to nested block device field in resource `maas_machine`. Other resources can now reference this block device by referencing this id. 

## Issue or ticket link (if applicable)

Resolves: #368 

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [ ] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.

## QA

The following QA was performed with this terraform plan: 

```bash

terraform-provider-maas/.devenv on  feat/add-id-to-machine-bdevice [$?] via 💠 default
❯ tf plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - canonical/maas in /home/dummy/work/terraform-provider-maas/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # maas_block_device_tag.test will be created
  + resource "maas_block_device_tag" "test" {
      + block_device_id = (known after apply)
      + id              = (known after apply)
      + machine         = (known after apply)
      + tags            = [
          + "test-tag",
        ]
    }

  # maas_machine.test will be created
  + resource "maas_machine" "test" {
      + architecture       = "amd64/generic"
      + block_devices      = (known after apply)
      + domain             = (known after apply)
      + hostname           = "tf-test-machine"
      + id                 = (known after apply)
      + min_hwe_kernel     = (known after apply)
      + network_interfaces = (known after apply)
      + pool               = (known after apply)
      + power_parameters   = (sensitive value)
      + power_type         = "lxd"
      + pxe_mac_address    = "00:16:3e:b5:2b:74"
      + zone               = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.

terraform-provider-maas/.devenv on  feat/add-id-to-machine-bdevice [$?] via 💠 default
❯ tf apply --auto-approve
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - canonical/maas in /home/dummy/work/terraform-provider-maas/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # maas_block_device_tag.test will be created
  + resource "maas_block_device_tag" "test" {
      + block_device_id = (known after apply)
      + id              = (known after apply)
      + machine         = (known after apply)
      + tags            = [
          + "test-tag",
        ]
    }

  # maas_machine.test will be created
  + resource "maas_machine" "test" {
      + architecture       = "amd64/generic"
      + block_devices      = (known after apply)
      + domain             = (known after apply)
      + hostname           = "tf-test-machine"
      + id                 = (known after apply)
      + min_hwe_kernel     = (known after apply)
      + network_interfaces = (known after apply)
      + pool               = (known after apply)
      + power_parameters   = (sensitive value)
      + power_type         = "lxd"
      + pxe_mac_address    = "00:16:3e:b5:2b:74"
      + zone               = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
maas_machine.test: Creating...
maas_machine.test: Still creating... [00m10s elapsed]
maas_machine.test: Still creating... [00m20s elapsed]
maas_machine.test: Still creating... [00m30s elapsed]
maas_machine.test: Still creating... [00m40s elapsed]
maas_machine.test: Still creating... [00m50s elapsed]
maas_machine.test: Still creating... [01m00s elapsed]
maas_machine.test: Still creating... [01m10s elapsed]
maas_machine.test: Still creating... [01m20s elapsed]
maas_machine.test: Still creating... [01m30s elapsed]
maas_machine.test: Still creating... [01m40s elapsed]
maas_machine.test: Still creating... [01m50s elapsed]
maas_machine.test: Creation complete after 1m52s [id=wbsa8n]
maas_block_device_tag.test: Creating...
maas_block_device_tag.test: Creation complete after 1s [id=wbsa8n/87]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

terraform-provider-maas/.devenv on  feat/add-id-to-machine-bdevice [$?] via 💠 default took 1m52s
❯ tf plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - canonical/maas in /home/dummy/work/terraform-provider-maas/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵
maas_machine.test: Refreshing state... [id=wbsa8n]
maas_block_device_tag.test: Refreshing state... [id=wbsa8n/87]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

terraform-provider-maas/.devenv on  feat/add-id-to-machine-bdevice [$?] via 💠 default
❯ tf state show maas_machine.test
# maas_machine.test:
resource "maas_machine" "test" {
    architecture       = "amd64/generic"
    block_devices      = [
        {
            id             = 87
            id_path        = "/dev/disk/by-id/scsi-SQEMU_QEMU_HARDDISK_lxd_root"
            model          = "QEMU HARDDISK"
            name           = "sda"
            serial         = "lxd_root"
            size_gigabytes = 8
        },
    ]
    domain             = "maas"
    hostname           = "tf-test-machine"
    id                 = "wbsa8n"
    min_hwe_kernel     = null
    network_interfaces = [
        "00:16:3e:b5:2b:74",
    ]
    pool               = "default"
    power_parameters   = (sensitive value)
    power_type         = "lxd"
    pxe_mac_address    = "00:16:3e:b5:2b:74"
    zone               = "default"
}

terraform-provider-maas/.devenv on  feat/add-id-to-machine-bdevice [$?] via 💠 default
❯ tf destroy --auto-approve
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - canonical/maas in /home/dummy/work/terraform-provider-maas/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published
│ releases.
╵
maas_machine.test: Refreshing state... [id=wbsa8n]
maas_block_device_tag.test: Refreshing state... [id=wbsa8n/87]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # maas_block_device_tag.test will be destroyed
  - resource "maas_block_device_tag" "test" {
      - block_device_id = 87 -> null
      - id              = "wbsa8n/87" -> null
      - machine         = "wbsa8n" -> null
      - tags            = [
          - "test-tag",
        ] -> null
    }

  # maas_machine.test will be destroyed
  - resource "maas_machine" "test" {
      - architecture       = "amd64/generic" -> null
      - block_devices      = [
          - {
              - id             = 87
              - id_path        = "/dev/disk/by-id/scsi-SQEMU_QEMU_HARDDISK_lxd_root"
              - model          = "QEMU HARDDISK"
              - name           = "sda"
              - serial         = "lxd_root"
              - size_gigabytes = 8
            },
        ] -> null
      - domain             = "maas" -> null
      - hostname           = "tf-test-machine" -> null
      - id                 = "wbsa8n" -> null
      - network_interfaces = [
          - "00:16:3e:b5:2b:74",
        ] -> null
      - pool               = "default" -> null
      - power_parameters   = (sensitive value) -> null
      - power_type         = "lxd" -> null
      - pxe_mac_address    = "00:16:3e:b5:2b:74" -> null
      - zone               = "default" -> null
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 0 to change, 2 to destroy.
maas_block_device_tag.test: Destroying... [id=wbsa8n/87]
maas_block_device_tag.test: Destruction complete after 0s
maas_machine.test: Destroying... [id=wbsa8n]
maas_machine.test: Destruction complete after 0s

Destroy complete! Resources: 2 destroyed.
```
