### PR TITLE
feat: redeploy machines

### DIFF
--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -371,7 +371,6 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta any)
 		"ip_addresses": ipAddresses,
 	}
 	if err := setTerraformState(d, tfState); err != nil {
-		return diag.Errorf("Machine set tfstate failed on read")
 		return diag.FromErr(err)
 	}
 

--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -348,6 +348,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta any)
 	if err != nil {
 		return unsetIfNotFoundError(d, err)
 	}
+	// remove from state if not deployed
 	if machine.Status != node.StatusDeployed {
 		d.SetId("")
 		return nil

--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/canonical/gomaasclient/client"
 	"github.com/canonical/gomaasclient/entity"
+	"github.com/canonical/gomaasclient/entity/node"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -345,7 +346,11 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta any)
 	// Get MAAS machine
 	machine, err := client.Machine.Get(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return unsetIfNotFoundError(d, err)
+	}
+	if machine.Status != node.StatusDeployed {
+		d.SetId("")
+		return nil
 	}
 	// Set Terraform state
 	ipAddresses := make([]string, len(machine.IPAddresses))

--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -371,6 +371,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta any)
 		"ip_addresses": ipAddresses,
 	}
 	if err := setTerraformState(d, tfState); err != nil {
+		return diag.Errorf("Machine set tfstate failed on read")
 		return diag.FromErr(err)
 	}
 
@@ -390,13 +391,13 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta an
 	// Release MAAS machine
 	_, err := client.Machine.Release(d.Id(), releaseParams)
 	if err != nil {
-		return diag.FromErr(err)
+		return unsetIfNotFoundError(d, err)
 	}
 
 	// Wait MAAS machine to be released
 	_, err = waitForMachineStatus(ctx, client, d.Id(), []string{"Releasing", "Disk erasing"}, []string{"Ready"}, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return diag.FromErr(err)
+		return unsetIfNotFoundError(d, err)
 	}
 
 	return nil

--- a/maas/resource_maas_vm_host_machine.go
+++ b/maas/resource_maas_vm_host_machine.go
@@ -196,7 +196,7 @@ func resourceVMHostMachineRead(ctx context.Context, d *schema.ResourceData, meta
 	// Get VM host machine
 	machine, err := client.Machine.Get(d.Id())
 	if err != nil {
-		return diag.FromErr(err)
+		return unsetIfNotFoundError(d, err)
 	}
 
 	// Set Terraform state

--- a/maas/resource_maas_vm_host_machine.go
+++ b/maas/resource_maas_vm_host_machine.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/canonical/gomaasclient/entity"
+	"github.com/canonical/gomaasclient/entity/node"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -197,6 +198,11 @@ func resourceVMHostMachineRead(ctx context.Context, d *schema.ResourceData, meta
 	machine, err := client.Machine.Get(d.Id())
 	if err != nil {
 		return unsetIfNotFoundError(d, err)
+	}
+	// remove from state if not deployed
+	if machine.Status != node.StatusDeployed {
+		d.SetId("")
+		return nil
 	}
 
 	// Set Terraform state

--- a/maas/resource_maas_vm_host_machine.go
+++ b/maas/resource_maas_vm_host_machine.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/canonical/gomaasclient/entity"
-	"github.com/canonical/gomaasclient/entity/node"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/maas/resource_maas_vm_host_machine.go
+++ b/maas/resource_maas_vm_host_machine.go
@@ -199,11 +199,6 @@ func resourceVMHostMachineRead(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		return unsetIfNotFoundError(d, err)
 	}
-	// remove from state if not deployed
-	if machine.Status != node.StatusDeployed {
-		d.SetId("")
-		return nil
-	}
 
 	// Set Terraform state
 	tfState := map[string]any{


### PR DESCRIPTION
## Description of changes

<!-- A clear and concise description of your changes here. -->

Following on from the work with #415, #428, and #433, we unset `maas_instance` machines in terraform if they are not found (manually deleted) or if the machine is *not* in a deployed state.
Terraform will then recreate the machine on an update/create operation.

Additionally, because terraform waits for the machine status, there is a high chance when deleting the instance that a "404 Not Found" error will occur, so we additionally apply a nil operation in that case.

This can lead to dangling resources, so users will have to manually remove any machines not in the valid state manually once terraform has redeployed.

## Issue or ticket link (if applicable)

fixes: #257

<!--
Please link the issue this PR addresses using GitHub’s keywords to automatically close related issues. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

e.g. Resolves: #XXX -->

## QA Plan
For purposes of QA we will be using the following maas-instance plan below to create resources.

#### Terraform plan
<details>
<summary>Terraform plan used in QA steps...</summary>

```terraform
terraform {
  required_providers {
    maas = {
      source = "canonical/maas"
    }
  }
}

locals {
  vm_hostname = "maas-host"

  cpu_count = 1
  memory    = 2048
}

provider "maas" {
  api_key = "$API_KEY"
  api_url = "$API_URL"
}

resource "maas_instance" "instance" {
  count = 1
  allocate_params {
    hostname      = "test vm"
    min_cpu_count = local.cpu_count
    min_memory    = local.memory
  }
  deploy_params {
    distro_series = "noble"
  }
}
```

</details>

steps:
1. create the resources with the terraform plan above
2. delete/undeploy the instance on the MAAS ui, to simulate schema drift
3. run a terraform delete, or modify the plan above and terraform apply to update, watching for the failure.
4. cleanly remove the resources to start again.

below is the output for each QA topology:

#### QA
<details>
<summary>Machine recreated on apply</summary>

Deleting the Machine, then applying changes triggers resource read. the MAAS 404 is captured, causing state to unset, and the missing resource is created without throwing an exception

`terraform apply -auto-approve`
```bash
maas_instance.instance[0]: Refreshing state... [id=aqfe3b]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # maas_instance.instance[0] will be created
  + resource "maas_instance" "instance" {
      + architecture = (known after apply)
      + cpu_count    = (known after apply)
      + fqdn         = (known after apply)
      + hostname     = (known after apply)
      + id           = (known after apply)
      + ip_addresses = (known after apply)
      + memory       = (known after apply)
      + pool         = (known after apply)
      + tags         = (known after apply)
      + zone         = (known after apply)

      + allocate_params {
          + hostname      = "test vm"
          + min_cpu_count = 2
          + min_memory    = 2048
        }

      + deploy_params {
          + distro_series = "noble"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
maas_instance.instance[0]: Creating...
maas_instance.instance[0]: Still creating... [00m10s elapsed]
maas_instance.instance[0]: Still creating... [00m20s elapsed]
maas_instance.instance[0]: Still creating... [00m30s elapsed]
maas_instance.instance[0]: Still creating... [00m40s elapsed]
maas_instance.instance[0]: Still creating... [00m50s elapsed]
maas_instance.instance[0]: Still creating... [01m00s elapsed]
maas_instance.instance[0]: Still creating... [01m10s elapsed]
maas_instance.instance[0]: Still creating... [01m20s elapsed]
maas_instance.instance[0]: Still creating... [01m30s elapsed]
maas_instance.instance[0]: Still creating... [01m40s elapsed]
maas_instance.instance[0]: Still creating... [01m50s elapsed]
maas_instance.instance[0]: Still creating... [02m00s elapsed]
maas_instance.instance[0]: Still creating... [02m10s elapsed]
maas_instance.instance[0]: Still creating... [02m20s elapsed]
maas_instance.instance[0]: Still creating... [02m30s elapsed]
maas_instance.instance[0]: Still creating... [02m40s elapsed]
maas_instance.instance[0]: Creation complete after 2m45s [id=mya3wk]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Moving the machine to an undeployed state (broken, ready, etc...) also performs the same unset and recreation

`terraform apply -auto-approve`
```bash
maas_instance.instance[0]: Refreshing state... [id=mya3wk]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # maas_instance.instance[0] will be created
  + resource "maas_instance" "instance" {
      + architecture = (known after apply)
      + cpu_count    = (known after apply)
      + fqdn         = (known after apply)
      + hostname     = (known after apply)
      + id           = (known after apply)
      + ip_addresses = (known after apply)
      + memory       = (known after apply)
      + pool         = (known after apply)
      + tags         = (known after apply)
      + zone         = (known after apply)

      + allocate_params {
          + hostname      = "test vm"
          + min_cpu_count = 2
          + min_memory    = 2048
        }

      + deploy_params {
          + distro_series = "noble"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
maas_instance.instance[0]: Creating...
maas_instance.instance[0]: Still creating... [00m10s elapsed]
maas_instance.instance[0]: Still creating... [00m20s elapsed]
maas_instance.instance[0]: Still creating... [00m30s elapsed]
maas_instance.instance[0]: Still creating... [00m40s elapsed]
maas_instance.instance[0]: Still creating... [00m50s elapsed]
maas_instance.instance[0]: Still creating... [01m00s elapsed]
maas_instance.instance[0]: Still creating... [01m10s elapsed]
maas_instance.instance[0]: Still creating... [01m20s elapsed]
maas_instance.instance[0]: Still creating... [01m30s elapsed]
maas_instance.instance[0]: Still creating... [01m40s elapsed]
maas_instance.instance[0]: Still creating... [01m50s elapsed]
maas_instance.instance[0]: Still creating... [02m00s elapsed]
maas_instance.instance[0]: Still creating... [02m10s elapsed]
maas_instance.instance[0]: Still creating... [02m20s elapsed]
maas_instance.instance[0]: Still creating... [02m30s elapsed]
maas_instance.instance[0]: Still creating... [02m40s elapsed]
maas_instance.instance[0]: Creation complete after 2m44s [id=whwq7m]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

</details>

<details>
<summary>Clean Machine teardown</summary>

Deleting the MAchine and running destroy operation clears the state. The read unsets the id, and terraform exits cleanly without a "resource not found" exception.
Because this is a delete operation, the resources are actually wip

`terraform destroy -auto-approve`
```bash
maas_instance.instance[0]: Refreshing state... [id=whwq7m]

No changes. No objects need to be destroyed.

Either you have not created any objects yet or the existing objects were already deleted outside of Terraform.

Destroy complete! Resources: 0 destroyed.
```

Moving the machine to an undeployed state also performs the same unset and clean exit

`terraform apply -auto-approve`
```bash
maas_instance.instance[0]: Refreshing state... [id=tdq7q6]

No changes. No objects need to be destroyed.

Either you have not created any objects yet or the existing objects were already deleted outside of Terraform.

Destroy complete! Resources: 0 destroyed.
```

</details>

<details>
<summary>MAchine drift mid-workflow</summary>

Deleting the Machine between plan and apply should still run the safe terraform read. The resource is detected as missing, and create is triggered instead of update.

`terraform plan`
```bash
maas_instance.instance[0]: Refreshing state... [id=4s7a47]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # maas_instance.instance[0] must be replaced
-/+ resource "maas_instance" "instance" {
      ~ architecture = "amd64/generic" -> (known after apply)
      ~ cpu_count    = 2 -> (known after apply)
      ~ fqdn         = "in-fowl.maas" -> (known after apply)
      ~ hostname     = "in-fowl" -> (known after apply)
      ~ id           = "4s7a47" -> (known after apply)
      ~ ip_addresses = [
          - "10.20.0.16",
        ] -> (known after apply)
      ~ memory       = 2048 -> (known after apply)
      ~ pool         = "default" -> (known after apply)
      ~ tags         = [
          - "pod-console-logging",
        ] -> (known after apply)
      ~ zone         = "default" -> (known after apply)

      ~ allocate_params {
          ~ min_cpu_count = 2 -> 1 # forces replacement
          - tags          = [] -> null
            # (6 unchanged attributes hidden)
        }

      ~ deploy_params {
          - enable_hw_sync = false -> null
          - ephemeral      = false -> null
            # (3 unchanged attributes hidden)
        }
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

`terraform apply -auto-approve`
```bash
maas_instance.instance[0]: Refreshing state... [id=4s7a47]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # maas_instance.instance[0] will be created
  + resource "maas_instance" "instance" {
      + architecture = (known after apply)
      + cpu_count    = (known after apply)
      + fqdn         = (known after apply)
      + hostname     = (known after apply)
      + id           = (known after apply)
      + ip_addresses = (known after apply)
      + memory       = (known after apply)
      + pool         = (known after apply)
      + tags         = (known after apply)
      + zone         = (known after apply)

      + allocate_params {
          + hostname      = "test vm"
          + min_cpu_count = 1
          + min_memory    = 2048
        }

      + deploy_params {
          + distro_series = "noble"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
maas_instance.instance[0]: Creating...
maas_instance.instance[0]: Still creating... [00m10s elapsed]
maas_instance.instance[0]: Still creating... [00m20s elapsed]
maas_instance.instance[0]: Still creating... [00m30s elapsed]
maas_instance.instance[0]: Still creating... [00m40s elapsed]
maas_instance.instance[0]: Still creating... [00m50s elapsed]
maas_instance.instance[0]: Still creating... [01m00s elapsed]
maas_instance.instance[0]: Still creating... [01m10s elapsed]
maas_instance.instance[0]: Still creating... [01m20s elapsed]
maas_instance.instance[0]: Still creating... [01m30s elapsed]
maas_instance.instance[0]: Still creating... [01m40s elapsed]
maas_instance.instance[0]: Still creating... [01m50s elapsed]
maas_instance.instance[0]: Still creating... [02m00s elapsed]
maas_instance.instance[0]: Still creating... [02m10s elapsed]
maas_instance.instance[0]: Still creating... [02m20s elapsed]
maas_instance.instance[0]: Still creating... [02m30s elapsed]
maas_instance.instance[0]: Still creating... [02m40s elapsed]
maas_instance.instance[0]: Still creating... [02m50s elapsed]
maas_instance.instance[0]: Still creating... [03m00s elapsed]
maas_instance.instance[0]: Still creating... [03m10s elapsed]
maas_instance.instance[0]: Creation complete after 3m16s [id=dtkxbb]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Moving the machine to an undeployed state also performs the same unset and recreate

`terraform plan`
```bash
maas_instance.instance[0]: Refreshing state... [id=dtkxbb]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # maas_instance.instance[0] must be replaced
-/+ resource "maas_instance" "instance" {
      ~ architecture = "amd64/generic" -> (known after apply)
      ~ cpu_count    = 1 -> (known after apply)
      ~ fqdn         = "trusty-thrush.maas" -> (known after apply)
      ~ hostname     = "trusty-thrush" -> (known after apply)
      ~ id           = "dtkxbb" -> (known after apply)
      ~ ip_addresses = [
          - "10.20.0.17",
        ] -> (known after apply)
      ~ memory       = 2048 -> (known after apply)
      ~ pool         = "default" -> (known after apply)
      ~ tags         = [
          - "pod-console-logging",
        ] -> (known after apply)
      ~ zone         = "default" -> (known after apply)

      ~ allocate_params {
          ~ min_cpu_count = 1 -> 2 # forces replacement
          - tags          = [] -> null
            # (6 unchanged attributes hidden)
        }

      ~ deploy_params {
          - enable_hw_sync = false -> null
          - ephemeral      = false -> null
            # (3 unchanged attributes hidden)
        }
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

`terraform apply -auto-approve`
```bash
maas_instance.instance[0]: Refreshing state... [id=dtkxbb]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # maas_instance.instance[0] will be created
  + resource "maas_instance" "instance" {
      + architecture = (known after apply)
      + cpu_count    = (known after apply)
      + fqdn         = (known after apply)
      + hostname     = (known after apply)
      + id           = (known after apply)
      + ip_addresses = (known after apply)
      + memory       = (known after apply)
      + pool         = (known after apply)
      + tags         = (known after apply)
      + zone         = (known after apply)

      + allocate_params {
          + hostname      = "test vm"
          + min_cpu_count = 2
          + min_memory    = 2048
        }

      + deploy_params {
          + distro_series = "noble"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
maas_instance.instance[0]: Creating...
maas_instance.instance[0]: Still creating... [00m10s elapsed]
maas_instance.instance[0]: Still creating... [00m20s elapsed]
maas_instance.instance[0]: Still creating... [00m30s elapsed]
maas_instance.instance[0]: Still creating... [00m40s elapsed]
maas_instance.instance[0]: Still creating... [00m50s elapsed]
maas_instance.instance[0]: Still creating... [01m00s elapsed]
maas_instance.instance[0]: Still creating... [01m10s elapsed]
maas_instance.instance[0]: Still creating... [01m20s elapsed]
maas_instance.instance[0]: Still creating... [01m30s elapsed]
maas_instance.instance[0]: Still creating... [01m40s elapsed]
maas_instance.instance[0]: Still creating... [01m50s elapsed]
maas_instance.instance[0]: Still creating... [02m00s elapsed]
maas_instance.instance[0]: Still creating... [02m10s elapsed]
maas_instance.instance[0]: Still creating... [02m20s elapsed]
maas_instance.instance[0]: Still creating... [02m30s elapsed]
maas_instance.instance[0]: Still creating... [02m40s elapsed]
maas_instance.instance[0]: Still creating... [02m50s elapsed]
maas_instance.instance[0]: Still creating... [03m00s elapsed]
maas_instance.instance[0]: Creation complete after 3m7s [id=cbbnhw]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

</details>

<details>
<summary>Machine deletion race condition with saved plan</summary>

Deleting the Machine between plan and apply, while forcing terraform to use the plan. This hits update (which is just read), unsetting the resource and verifying destruction, before recreating the machine

`terraform plan -out=tfplan`
```bash
maas_instance.instance[0]: Refreshing state... [id=cbbnhw]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # maas_instance.instance[0] must be replaced
-/+ resource "maas_instance" "instance" {
      ~ architecture = "amd64/generic" -> (known after apply)
      ~ cpu_count    = 2 -> (known after apply)
      ~ fqdn         = "trusty-whale.maas" -> (known after apply)
      ~ hostname     = "trusty-whale" -> (known after apply)
      ~ id           = "cbbnhw" -> (known after apply)
      ~ ip_addresses = [
          - "10.20.0.18",
        ] -> (known after apply)
      ~ memory       = 2048 -> (known after apply)
      ~ pool         = "default" -> (known after apply)
      ~ tags         = [
          - "pod-console-logging",
        ] -> (known after apply)
      ~ zone         = "default" -> (known after apply)

      ~ allocate_params {
          ~ min_cpu_count = 2 -> 1 # forces replacement
          - tags          = [] -> null
            # (6 unchanged attributes hidden)
        }

      ~ deploy_params {
          - enable_hw_sync = false -> null
          - ephemeral      = false -> null
            # (3 unchanged attributes hidden)
        }
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Saved the plan to: tfplan

To perform exactly these actions, run the following command to apply:
    terraform apply "tfplan"
```

`terraform apply "tfplan"`
```bash
maas_instance.instance[0]: Destroying... [id=xqcbn6]
maas_instance.instance[0]: Destruction complete after 0s
maas_instance.instance[0]: Creating...
maas_instance.instance[0]: Still creating... [00m10s elapsed]
maas_instance.instance[0]: Still creating... [00m20s elapsed]
maas_instance.instance[0]: Still creating... [00m30s elapsed]
maas_instance.instance[0]: Still creating... [00m40s elapsed]
maas_instance.instance[0]: Still creating... [00m50s elapsed]
maas_instance.instance[0]: Still creating... [01m00s elapsed]
maas_instance.instance[0]: Still creating... [01m10s elapsed]
maas_instance.instance[0]: Still creating... [01m20s elapsed]
maas_instance.instance[0]: Still creating... [01m30s elapsed]
maas_instance.instance[0]: Still creating... [01m40s elapsed]
maas_instance.instance[0]: Still creating... [01m50s elapsed]
maas_instance.instance[0]: Still creating... [02m00s elapsed]
maas_instance.instance[0]: Still creating... [02m10s elapsed]
maas_instance.instance[0]: Still creating... [02m20s elapsed]
maas_instance.instance[0]: Still creating... [02m30s elapsed]
maas_instance.instance[0]: Still creating... [02m40s elapsed]
maas_instance.instance[0]: Still creating... [02m50s elapsed]
maas_instance.instance[0]: Still creating... [03m00s elapsed]
maas_instance.instance[0]: Creation complete after 3m6s [id=ya8kgq]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```

Moving the machine to an undeployed state also results in *almost* the same.
If the machine is in a state where terraform cannot destroy, i.e.: rescue mode, then an error as expected will be returned, instead of the recreation operation.

`terraform plan -out=tfplan`
```bash
maas_instance.instance[0]: Refreshing state... [id=ya8kgq]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # maas_instance.instance[0] must be replaced
-/+ resource "maas_instance" "instance" {
      ~ architecture = "amd64/generic" -> (known after apply)
      ~ cpu_count    = 2 -> (known after apply)
      ~ fqdn         = "trusty-dingo.maas" -> (known after apply)
      ~ hostname     = "trusty-dingo" -> (known after apply)
      ~ id           = "ya8kgq" -> (known after apply)
      ~ ip_addresses = [
          - "10.20.0.21",
        ] -> (known after apply)
      ~ memory       = 2048 -> (known after apply)
      ~ pool         = "default" -> (known after apply)
      ~ tags         = [
          - "pod-console-logging",
        ] -> (known after apply)
      ~ zone         = "default" -> (known after apply)

      ~ allocate_params {
          ~ min_cpu_count = 2 -> 1 # forces replacement
          - tags          = [] -> null
            # (6 unchanged attributes hidden)
        }

      ~ deploy_params {
          - enable_hw_sync = false -> null
          - ephemeral      = false -> null
            # (3 unchanged attributes hidden)
        }
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Saved the plan to: tfplan

To perform exactly these actions, run the following command to apply:
    terraform apply "tfplan"
```

safe recreation

`terraform apply "tfplan"`
```bash
maas_instance.instance[0]: Destroying... [id=ya8kgq]
maas_instance.instance[0]: Still destroying... [id=ya8kgq, 00m10s elapsed]
maas_instance.instance[0]: Destruction complete after 11s
maas_instance.instance[0]: Creating...
maas_instance.instance[0]: Still creating... [00m10s elapsed]
maas_instance.instance[0]: Still creating... [00m20s elapsed]
maas_instance.instance[0]: Still creating... [00m30s elapsed]
maas_instance.instance[0]: Still creating... [00m40s elapsed]
maas_instance.instance[0]: Still creating... [00m50s elapsed]
maas_instance.instance[0]: Still creating... [01m00s elapsed]
maas_instance.instance[0]: Still creating... [01m10s elapsed]
maas_instance.instance[0]: Still creating... [01m20s elapsed]
maas_instance.instance[0]: Still creating... [01m30s elapsed]
maas_instance.instance[0]: Still creating... [01m40s elapsed]
maas_instance.instance[0]: Still creating... [01m50s elapsed]
maas_instance.instance[0]: Still creating... [02m00s elapsed]
maas_instance.instance[0]: Still creating... [02m10s elapsed]
maas_instance.instance[0]: Still creating... [02m20s elapsed]
maas_instance.instance[0]: Still creating... [02m30s elapsed]
maas_instance.instance[0]: Still creating... [02m40s elapsed]
maas_instance.instance[0]: Still creating... [02m50s elapsed]
maas_instance.instance[0]: Still creating... [03m00s elapsed]
maas_instance.instance[0]: Creation complete after 3m5s [id=brgbew]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```

An example in a non-releasable state

`terraform apply "tfplan"`
```bash
maas_instance.instance[0]: Destroying... [id=ya8kgq]
╷
│ Error: ServerError: 409 Conflict (Machine cannot be released in its current state ('Rescue mode').)
│ 
│ 
╵
```

</details>

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [ ] I have run the acceptance tests and they pass.
