### PR TITLE
feat: add block_devices attribute to maas_machine data source

### DIFF
--- a/docs/data-sources/machine.md
+++ b/docs/data-sources/machine.md
@@ -42,6 +42,7 @@ data "maas_machine" "test_by_pxe_mac_address" {
 ### Read-Only
 
 - `architecture` (String) The architecture type of the machine.
+- `block_devices` (List of Object) A list of physical block devices attached to the machine. (see [below for nested schema](#nestedatt--block_devices))
 - `domain` (String) The domain of the machine.
 - `id` (String) The ID of this resource.
 - `min_hwe_kernel` (String) The minimum kernel version allowed to run on this machine.
@@ -50,3 +51,15 @@ data "maas_machine" "test_by_pxe_mac_address" {
 - `power_type` (String) The power management type (e.g. `ipmi`) of the machine.
 - `status` (String) The machine status
 - `zone` (String) The zone of the machine.
+
+<a id="nestedatt--block_devices"></a>
+### Nested Schema for `block_devices`
+
+Read-Only:
+
+- `id` (Number)
+- `id_path` (String)
+- `model` (String)
+- `name` (String)
+- `serial` (String)
+- `size_gigabytes` (Number)

--- a/maas/data_source_maas_machine.go
+++ b/maas/data_source_maas_machine.go
@@ -3,6 +3,7 @@ package maas
 import (
 	"context"
 
+	"github.com/canonical/gomaasclient/entity"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
@@ -17,6 +18,45 @@ func dataSourceMAASMachine() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The architecture type of the machine.",
+			},
+			"block_devices": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "A list of physical block devices attached to the machine.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The ID of the block device.",
+						},
+						"id_path": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID path of the block device.",
+						},
+						"model": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The model of the block device.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The block device name.",
+						},
+						"serial": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The serial number of the block device.",
+						},
+						"size_gigabytes": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The size of the block device (in GB).",
+						},
+					},
+				},
 			},
 			"domain": {
 				Type:        schema.TypeString,
@@ -98,6 +138,22 @@ func dataSourceMachineRead(ctx context.Context, d *schema.ResourceData, meta any
 		return diag.FromErr(err)
 	}
 
+	allBlockDevices, err := client.BlockDevices.Get(machine.SystemID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Virtual block devices will be managed by Terraform resources, so do not add value
+	// by being here. Filtering them out prevents uneccassary plan changes after
+	// other resources create virtual block devices.
+	physicalBlockDevices := make([]entity.BlockDevice, 0)
+
+	for _, bd := range allBlockDevices {
+		if bd.Type != "physical" {
+			physicalBlockDevices = append(physicalBlockDevices, bd)
+		}
+	}
+
 	tfState := map[string]any{
 		"id":               machine.SystemID,
 		"architecture":     machine.Architecture,
@@ -110,6 +166,7 @@ func dataSourceMachineRead(ctx context.Context, d *schema.ResourceData, meta any
 		"power_parameters": powerParamsJSON,
 		"pxe_mac_address":  machine.BootInterface.MACAddress,
 		"status":           machine.StatusName,
+		"block_devices":    getAllBlockDeviceMachineParameters(physicalBlockDevices),
 	}
 	if err := setTerraformState(d, tfState); err != nil {
 		return diag.FromErr(err)

--- a/maas/data_source_maas_machine.go
+++ b/maas/data_source_maas_machine.go
@@ -149,7 +149,7 @@ func dataSourceMachineRead(ctx context.Context, d *schema.ResourceData, meta any
 	physicalBlockDevices := make([]entity.BlockDevice, 0)
 
 	for _, bd := range allBlockDevices {
-		if bd.Type != "physical" {
+		if bd.Type == "physical" {
 			physicalBlockDevices = append(physicalBlockDevices, bd)
 		}
 	}

--- a/maas/data_source_maas_machine.go
+++ b/maas/data_source_maas_machine.go
@@ -144,7 +144,7 @@ func dataSourceMachineRead(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	// Virtual block devices will be managed by Terraform resources, so do not add value
-	// by being here. Filtering them out prevents uneccassary plan changes after
+	// by being here. Filtering them out prevents unnecessary plan changes after
 	// other resources create virtual block devices.
 	physicalBlockDevices := make([]entity.BlockDevice, 0)
 

--- a/maas/data_source_maas_machine_test.go
+++ b/maas/data_source_maas_machine_test.go
@@ -3,12 +3,14 @@ package maas_test
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"terraform-provider-maas/maas/testutils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDataSourceMAASMachine_basic(t *testing.T) {
@@ -33,10 +35,33 @@ func TestAccDataSourceMAASMachine_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.maas_machine.test", "pxe_mac_address"),
 					resource.TestCheckResourceAttr("data.maas_machine.test", "status", "Ready"),
 					resource.TestCheckResourceAttrSet("data.maas_machine.test", "zone"),
+					resource.TestCheckResourceAttrSet("data.maas_machine.test", "block_devices.#"),
+					testAccCheckNoBlockDeviceWithName("data.maas_machine.test", "test-volume-group-virtual-test"),
 				),
 			},
 		},
 	})
+}
+
+func testAccCheckNoBlockDeviceWithName(resourceName, deviceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		countStr := rs.Primary.Attributes["block_devices.#"]
+
+		count, _ := strconv.Atoi(countStr)
+		for i := 0; i < count; i++ {
+			name := rs.Primary.Attributes[fmt.Sprintf("block_devices.%d.name", i)]
+			if name == deviceName {
+				return fmt.Errorf("block_devices contains a virtual device %q but only physical devices should be present", deviceName)
+			}
+		}
+
+		return nil
+	}
 }
 
 func testAccDataSourceMAASMachineVMHostConfig(vmHostID, testMachineName string) string {
@@ -46,8 +71,31 @@ resource "maas_vm_host_machine" "test" {
   hostname = %q
 }
 
+# Create a virtual block device to verify that only physical block devices are returned
+# by the data source
+resource "maas_block_device" "test" {
+  machine        = maas_vm_host_machine.test.id
+  name           = "test-block-device"
+  id_path        = "/dev/sda"
+  size_gigabytes = 2
+}
+
+resource "maas_volume_group" "test" {
+  machine       = maas_vm_host_machine.test.id
+  name          = "test-volume-group"
+  block_devices = [maas_block_device.test.id]
+}
+
+resource "maas_logical_volume" "test" {
+  machine        = maas_vm_host_machine.test.id
+  name           = "virtual-test"
+  volume_group   = maas_volume_group.test.id
+  size_gigabytes = 1
+}
+
 data "maas_machine" "test" {
-  hostname = maas_vm_host_machine.test.hostname
+  hostname   = maas_vm_host_machine.test.hostname
+  depends_on = [maas_logical_volume.test]
 }
 `, vmHostID, testMachineName)
 }


### PR DESCRIPTION
## Description of changes

Add `block_devices` nested schema to `maas_machine` data source. This filters for physical block devices only. 

AI was used in this PR.

## Issue or ticket link (if applicable)

Resolves: #419 

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
