### PR TITLE
fix: delete nested IP ranges before deleting the subnet

### DIFF
--- a/maas/resource_maas_subnet.go
+++ b/maas/resource_maas_subnet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/canonical/gomaasclient/client"
 	"github.com/canonical/gomaasclient/entity"
@@ -222,6 +223,20 @@ func resourceSubnetDelete(ctx context.Context, d *schema.ResourceData, meta any)
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	// Delete IP ranges tracked in state first
+	if ipRangesRaw, ok := d.GetOk("ip_ranges"); ok {
+		ipRangesSet := ipRangesRaw.(*schema.Set)
+		for _, i := range ipRangesSet.List() {
+			ipr := i.(map[string]any)
+			if rangeID, ok := ipr["id"]; ok {
+				err = client.IPRange.Delete(rangeID.(int))
+				if err != nil && !strings.Contains(err.Error(), "404 Not Found") {
+					return diag.FromErr(err)
+				}
+			}
+		}
 	}
 
 	if err := client.Subnet.Delete(id); err != nil {


### PR DESCRIPTION
## Description of changes

Before deleting a subnet, explicitly delete all IP ranges that are tracked in Terraform state (via the embedded `ip_ranges` attribute). This ensures that dynamic IP ranges are removed before attempting subnet deletion, preventing failures when the subnet's VLAN has DHCP enabled.

The implementation ignores 404 errors during IP range deletion to handle cases where ranges may have already been removed outside of Terraform.

### Limitations:

This approach only deletes IP ranges that Terraform is tracking in its state file. If users create IP ranges outside of Terraform or mix the embedded `ip_ranges` attribute with standalone `maas_subnet_ip_range` resources, those ranges will not be cleaned up automatically. In such cases, subnet deletion may still fail, and users will need to manually remove the untracked IP ranges before the subnet can be deleted.

<!-- A clear and concise description of your changes here. -->

## Issue or ticket link (if applicable)

Resolves: #167 
<!--
Please link the issue this PR addresses using GitHub’s keywords to automatically close related issues. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

e.g. Resolves: #XXX -->

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
