### PR TITLE
feat(maas-machine): adopt-by-MAC on Create conflict

### DIFF
--- a/maas/mac_conflict.go
+++ b/maas/mac_conflict.go
@@ -1,0 +1,67 @@
+package maas
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/canonical/gomaasclient/client"
+	"github.com/canonical/gomaasclient/entity"
+)
+
+// errMachineNotFound is returned by findMachineByMAC when no machine matches
+// the supplied MAC. Callers should use errors.Is to detect it instead of
+// branching on a nil-machine value.
+var errMachineNotFound = errors.New("maas: machine not found")
+
+// isMACConflict reports whether err is the MAAS 400 response that fires when a
+// machine with the same MAC address already exists. MAAS does not expose a
+// machine-readable error code; gomaasapi formats the response as
+//
+//	ServerError: 400 Bad Request (<json or list body>)
+//
+// Body shapes observed in practice (across MAAS 2.x / 3.x):
+//   - {"mac_addresses": ["MAC address xx:xx... already in use on <host>."]}
+//   - {"__all__":       ["A node with this MAC address already exists."]}
+//   - ["MAC address xx:xx... already in use on <host>."]
+//
+// Match strategy: status 400 + "mac" (case-insensitive) + "already" or "exists".
+// Conservative on purpose: avoids matching unrelated 400s, accepts any of the
+// observed phrasings.
+func isMACConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "400") {
+		return false
+	}
+
+	if !strings.Contains(msg, "mac") {
+		return false
+	}
+
+	return strings.Contains(msg, "already") || strings.Contains(msg, "exists")
+}
+
+// findMachineByMAC returns the MAAS machine whose boot-interface MAC matches
+// mac. Returns errMachineNotFound when no machine matches; callers should use
+// errors.Is(err, errMachineNotFound) to distinguish from API errors.
+func findMachineByMAC(c *client.Client, mac string) (*entity.Machine, error) {
+	machines, err := c.Machines.Get(&entity.MachinesParams{
+		MACAddress: []string{mac},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	want := strings.ToLower(strings.TrimSpace(mac))
+	for i := range machines {
+		got := strings.ToLower(strings.TrimSpace(machines[i].BootInterface.MACAddress))
+		if got == want {
+			return &machines[i], nil
+		}
+	}
+
+	return nil, errMachineNotFound
+}

--- a/maas/mac_conflict_test.go
+++ b/maas/mac_conflict_test.go
@@ -1,0 +1,55 @@
+package maas
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsMACConflict(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain", errors.New("boom"), false},
+		{
+			"mac-already-in-use",
+			errors.New(`ServerError: 400 Bad Request ({"mac_addresses": ["MAC address aa:bb:cc:dd:ee:ff already in use on host-1."]})`),
+			true,
+		},
+		{
+			"all-already-exists",
+			errors.New(`ServerError: 400 Bad Request ({"__all__": ["A node with this MAC address already exists."]})`),
+			true,
+		},
+		{
+			"list-already-in-use",
+			errors.New(`ServerError: 400 Bad Request (["MAC address aa:bb:cc:dd:ee:ff already in use on host-1."])`),
+			true,
+		},
+		{
+			"400-but-unrelated",
+			errors.New(`ServerError: 400 Bad Request ({"hostname": ["Invalid hostname."]})`),
+			false,
+		},
+		{
+			"500-error",
+			errors.New(`ServerError: 500 Internal Server Error (something went wrong with mac already)`),
+			false,
+		},
+		{
+			"timeout",
+			errors.New("dial tcp 1.2.3.4:80: i/o timeout"),
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isMACConflict(tc.err); got != tc.want {
+				t.Fatalf("isMACConflict(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/maas/resource_maas_machine.go
+++ b/maas/resource_maas_machine.go
@@ -274,7 +274,22 @@ func resourceMachineCreate(ctx context.Context, d *schema.ResourceData, meta any
 
 	machine, err := client.Machines.Create(getMachineCreateParams(d), powerParams)
 	if err != nil {
-		return diag.FromErr(err)
+		// Adopt-by-MAC on conflict. When MAAS already has a machine with the
+		// same boot MAC (typical after a transient failure mid-Create), fall
+		// through and reuse it instead of deadlocking on every retry.
+		if !isMACConflict(err) || !hasPxe {
+			return diag.FromErr(err)
+		}
+
+		existing, lookupErr := findMachineByMAC(client, pxeMacAddress.(string))
+		if lookupErr != nil {
+			return diag.FromErr(err)
+		}
+
+		log.Printf("[WARN] machine with MAC %s already exists (system_id %s); adopting",
+			pxeMacAddress.(string), existing.SystemID)
+
+		machine = existing
 	}
 
 	commissionedMachine, err := client.Machine.Commission(machine.SystemID, getMachineCommissionParams(d))


### PR DESCRIPTION
## Summary

When `client.Machines.Create` fails because MAAS already has a machine with
the supplied PXE MAC address, today the resource bubbles the 400 error and
aborts. That hits a deadlock in a common recovery path: a prior reconcile
committed the machine server-side but didn't write Terraform state (e.g. a
network blip mid-commission, or any non-deterministic post-Create failure).
Every retry from then on hits the same `400 MAC address already in use`
response and never recovers without manual cleanup.

This PR makes Create idempotent on this specific conflict shape: if the
error matches a MAC-conflict 400, look the existing machine up by MAC and
adopt it (treat it as the local `machine` value) instead of erroring.

## Detection

Conservative on purpose:

```go
strings.Contains(msg, "400") &&
strings.Contains(msg, "mac") &&
(strings.Contains(msg, "already") || strings.Contains(msg, "exists"))
```

Body shapes covered (observed across MAAS 2.x / 3.x):

- `{"mac_addresses": ["MAC address aa:bb:... already in use on host-1."]}`
- `{"__all__": ["A node with this MAC address already exists."]}`
- `["MAC address aa:bb:... already in use on host-1."]`

Unrelated 400s (validation errors on hostname, etc.) still fail loud.

## Lookup

Uses the public `Machines.Get(MachinesParams{MACAddress: …})` filter and
re-validates the match against `BootInterface.MACAddress` so we never adopt
the wrong machine. `findMachineByMAC` returns a sentinel `errMachineNotFound`
rather than nil/nil so callers can branch unambiguously.

## Scope

- New file `maas/mac_conflict.go` (~70 LOC) — `isMACConflict` +
  `findMachineByMAC` + `errMachineNotFound`.
- `maas/mac_conflict_test.go` — unit tests for all three body shapes plus
  the conservative-rejection cases.
- Single hunk in `maas/resource_maas_machine.go` `resourceMachineCreate`'s
  Create error path.

`go test ./maas/...` and `golangci-lint run ./maas/...` both clean.

## Related

Part of a small series of three independent PRs:

1. Retry transient HTTP errors during status polls — #459
2. (this PR) Adopt-by-MAC on Create conflict.
3. \`commission = false\` flag.

#1 and this PR pair naturally — together they let reconcile retries actually
self-heal after a transient mid-Create failure.

## Verification

Live-tested against a real MAAS install with the patched binary: deleted
local Terraform state, re-applied with the same MAC, observed Create return
the same `system_id` instead of erroring on the conflict.

## Test plan

- [x] Unit tests for body-shape detection.
- [x] Live re-apply test against MAAS 3.x — same `system_id` returned, no
      duplicate machine created.
- [ ] Reviewer feedback on the string-match heuristic vs a more structured
      detection (gomaasapi's `ServerError.StatusCode` could be used if a
      direct dependency is acceptable; current code stays at `errors.Error()`
      level to avoid widening imports).

## CLA

Signed under the email used in commits.