### PR TITLE
feat(maas-machine): add commission flag to skip auto-commissioning

### DIFF
--- a/maas/resource_maas_machine.go
+++ b/maas/resource_maas_machine.go
@@ -119,6 +119,15 @@ func resourceMAASMachine() *schema.Resource {
 					},
 				},
 			},
+			"commission": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				Description: "Whether to trigger commissioning after creating (or recommissioning during update) the machine. " +
+					"Set to false to register the machine without waiting for the multi-minute commission cycle " +
+					"(caller drives commissioning externally via the API or `maas commission`). When false, the " +
+					"machine ends up in `New` state and must be commissioned before it can be deployed. Defaults to true.",
+			},
 			"commissioning_scripts": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -277,6 +286,17 @@ func resourceMachineCreate(ctx context.Context, d *schema.ResourceData, meta any
 		return diag.FromErr(err)
 	}
 
+	// Save Id (commit early so non-commissioned machines are tracked).
+	d.SetId(machine.SystemID)
+
+	// Gate commission on the schema flag. When false, the machine remains
+	// in `New` state and the caller drives commissioning externally.
+	if !d.Get("commission").(bool) {
+		log.Printf("[INFO] commission=false; skipping commissioning for machine %s", machine.SystemID)
+
+		return resourceMachineRead(ctx, d, meta)
+	}
+
 	commissionedMachine, err := client.Machine.Commission(machine.SystemID, getMachineCommissionParams(d))
 	if err != nil {
 		log.Printf("[DEBUG] Machine (%s) cleaning up trailing resources\n", machine.SystemID)
@@ -288,9 +308,6 @@ func resourceMachineCreate(ctx context.Context, d *schema.ResourceData, meta any
 
 		return diag.FromErr(err)
 	}
-
-	// Save Id
-	d.SetId(machine.SystemID)
 
 	// Wait for machine to be ready
 	_, err = waitForMachineStatus(ctx, client, commissionedMachine.SystemID, []string{"Commissioning", "Testing"}, []string{"Ready"}, d.Timeout(schema.TimeoutCreate))
@@ -370,7 +387,9 @@ func resourceMachineUpdate(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	// One of the below cases is a special case for when machine is in "New" state. A user has imported this machine into Terraform and it needs to be commissioned to get to "Ready" state. Power parameters are assuming to be empty in the state at this point.
-	if scriptsHaveChanged || (powerParamsHaveChanged && machine.StatusName == "New") {
+	// When commission=false the caller is driving commissioning externally;
+	// skip the recommission path even when scripts or power params changed.
+	if d.Get("commission").(bool) && (scriptsHaveChanged || (powerParamsHaveChanged && machine.StatusName == "New")) {
 		machine, err = client.Machine.Commission(machine.SystemID, getMachineCommissionParams(d))
 		if err != nil {
 			return diag.FromErr(err)


### PR DESCRIPTION
## Summary

`maas_machine.Create` always drives the multi-minute commission cycle inline
and `Update` re-runs it whenever scripts or power params change. For
workflows where the caller drives commissioning externally — for example, a
Crossplane composer that owns a higher-level orchestration loop and wants
the machine entry registered synchronously without blocking on
commissioning — the inline cycle is both wasted time and a footgun on flaky
networks.

This PR adds a `commission` schema attribute (`bool`, optional, default
`true`) that gates:

- The `client.Machine.Commission` call + `waitForMachineStatus` in `Create`.
- The recommission block in `Update` (scripts changed, or power-params
  changed on a machine still in `New` state).

The default preserves existing behaviour so this is a non-breaking change.
When `false`, the resource Id is committed right after `Machines.Create`,
the machine stays in `New` state in MAAS, and the user must commission it
externally (`maas commission` or the API) before deploying.

## Why default true

Keeps the resource's existing semantics for everyone who isn't asking for
the opt-out. The schema doc note explicitly calls out the resulting `New`
state so users won't be surprised when a downstream `maas_instance.deploy`
or similar errors on an uncommissioned machine.

## Scope

Single file change (`maas/resource_maas_machine.go`):

- New schema field `commission` between `block_devices` and
  `commissioning_scripts` in the schema map.
- `Create`: move `d.SetId(...)` to right after `Machines.Create` (or after
  successful adoption when paired with the sister adopt-by-MAC PR), and
  short-circuit return after `resourceMachineRead` when `commission=false`.
- `Update`: gate the recommission block on `d.Get(\"commission\").(bool)`.

`go build` and `golangci-lint run ./maas/...` clean.

## Related

Part of a small series of three independent PRs:

1. Retry transient HTTP errors during status polls — #459
2. Adopt-by-MAC on Create conflict — #460
3. (this PR) `commission = false` flag.

This PR is the most decoupled of the three — it sidesteps the long-poll
class of failures entirely for callers willing to drive commissioning
themselves.

## Verification

Live-tested against a real MAAS install (with the patched binary):
`terraform apply -auto-approve` with `commission = false` and
`power_type = \"manual\"` returned in **~1 second** (compared with the
multi-minute commission cycle on stock v2.7.2). Machine appeared in MAAS in
`New` state, `terraform destroy` cleaned it up.

## Test plan

- [x] `go build ./...` clean.
- [x] Live apply / destroy against MAAS 3.x — apply <1s, destroy <1s, no
      orphan.
- [ ] Reviewer to confirm the schema doc note is sufficiently explicit
      about the resulting `New` state.

## CLA

Signed under the email used in commits.