### PR TITLE
refactor: Don't leave stale disks when renaming

### DIFF
--- a/maas/resource_maas_block_device.go
+++ b/maas/resource_maas_block_device.go
@@ -199,14 +199,11 @@ func resourceBlockDeviceCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	// 1. SMART SEARCH: Check if the disk already exists based on our hierarchy
-	// (id_path > model&serial > name)
 	blockDevice, err := findBlockDeviceFromSchema(client, machine.SystemID, d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// 2. CREATE (If not found): If our smart search returned nil, it truly doesn't exist.
 	if blockDevice == nil {
 		blockDevice, err = client.BlockDevices.Create(machine.SystemID, getBlockDeviceParams(d))
 		if err != nil {
@@ -214,10 +211,8 @@ func resourceBlockDeviceCreate(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
-	// 3. SAVE STATE: Lock in the immutable MAAS database ID
 	d.SetId(fmt.Sprintf("%v", blockDevice.ID))
 
-	// 4. SYNC CONFIG: Pass it to the UpdateContext to apply any name/tag changes
 	return resourceBlockDeviceUpdate(ctx, d, meta)
 }
 
@@ -341,6 +336,10 @@ func getBlockDeviceParams(d *schema.ResourceData) *entity.BlockDeviceParams {
 	}
 }
 
+// findBlockDeviceFromSchema searches for an existing block device on the machine using
+// a priority hierarchy: id_path (highest), then model+serial pair, then name (lowest).
+// The name match is deferred until after scanning all devices because it is the lowest
+// priority and should only be used as a fallback if no higher-priority match is found.
 func findBlockDeviceFromSchema(client *client.Client, machineID string, d *schema.ResourceData) (*entity.BlockDevice, error) {
 	blockDevices, err := client.BlockDevices.Get(machineID)
 	if err != nil {
@@ -370,11 +369,11 @@ func findBlockDeviceFromSchema(client *client.Client, machineID string, d *schem
 		}
 	}
 
+	// Only fall back to the name match if no higher-priority match was found.
 	if nameMatch != nil {
 		return nameMatch, nil
 	}
 
-	// No matches found
 	return nil, err
 }
 

--- a/maas/resource_maas_block_device.go
+++ b/maas/resource_maas_block_device.go
@@ -199,9 +199,16 @@ func resourceBlockDeviceCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	blockDevice, err := findBlockDevice(client, machine.SystemID, d.Get("name").(string))
+	blockDevice, err := findBlockDevice(client, machine.SystemID, d.Get("id_path").(string))
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	if blockDevice == nil {
+		blockDevice, err = findBlockDevice(client, machine.SystemID, d.Get("name").(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	if blockDevice == nil {

--- a/maas/resource_maas_block_device.go
+++ b/maas/resource_maas_block_device.go
@@ -369,7 +369,7 @@ func findBlockDeviceFromSchema(client *client.Client, machineID string, d *schem
 		}
 	}
 
-	return nameMatch, err
+	return nameMatch, nil
 }
 
 func findBlockDevice(client *client.Client, machineID string, identifier string) (*entity.BlockDevice, error) {

--- a/maas/resource_maas_block_device.go
+++ b/maas/resource_maas_block_device.go
@@ -369,12 +369,7 @@ func findBlockDeviceFromSchema(client *client.Client, machineID string, d *schem
 		}
 	}
 
-	// Only fall back to the name match if no higher-priority match was found.
-	if nameMatch != nil {
-		return nameMatch, nil
-	}
-
-	return nil, err
+	return nameMatch, err
 }
 
 func findBlockDevice(client *client.Client, machineID string, identifier string) (*entity.BlockDevice, error) {

--- a/maas/resource_maas_block_device.go
+++ b/maas/resource_maas_block_device.go
@@ -199,18 +199,14 @@ func resourceBlockDeviceCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	blockDevice, err := findBlockDevice(client, machine.SystemID, d.Get("id_path").(string))
+	// 1. SMART SEARCH: Check if the disk already exists based on our hierarchy
+	// (id_path > model&serial > name)
+	blockDevice, err := findBlockDeviceFromSchema(client, machine.SystemID, d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	if blockDevice == nil {
-		blockDevice, err = findBlockDevice(client, machine.SystemID, d.Get("name").(string))
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	}
-
+	// 2. CREATE (If not found): If our smart search returned nil, it truly doesn't exist.
 	if blockDevice == nil {
 		blockDevice, err = client.BlockDevices.Create(machine.SystemID, getBlockDeviceParams(d))
 		if err != nil {
@@ -218,8 +214,10 @@ func resourceBlockDeviceCreate(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
+	// 3. SAVE STATE: Lock in the immutable MAAS database ID
 	d.SetId(fmt.Sprintf("%v", blockDevice.ID))
 
+	// 4. SYNC CONFIG: Pass it to the UpdateContext to apply any name/tag changes
 	return resourceBlockDeviceUpdate(ctx, d, meta)
 }
 
@@ -341,6 +339,43 @@ func getBlockDeviceParams(d *schema.ResourceData) *entity.BlockDeviceParams {
 		Serial:    d.Get("serial").(string),
 		IDPath:    d.Get("id_path").(string),
 	}
+}
+
+func findBlockDeviceFromSchema(client *client.Client, machineID string, d *schema.ResourceData) (*entity.BlockDevice, error) {
+	blockDevices, err := client.BlockDevices.Get(machineID)
+	if err != nil {
+		return nil, err
+	}
+
+	idPath := d.Get("id_path").(string)
+	model := d.Get("model").(string)
+	serial := d.Get("serial").(string)
+	name := d.Get("name").(string)
+
+	var nameMatch *entity.BlockDevice
+
+	for i := range blockDevices {
+		b := blockDevices[i]
+
+		if idPath != "" && (b.IDPath == idPath || b.Path == idPath) {
+			return &blockDevices[i], nil
+		}
+
+		if model != "" && serial != "" && b.Model == model && b.Serial == serial {
+			return &blockDevices[i], nil
+		}
+
+		if name != "" && b.Name == name {
+			nameMatch = &blockDevices[i]
+		}
+	}
+
+	if nameMatch != nil {
+		return nameMatch, nil
+	}
+
+	// No matches found
+	return nil, err
 }
 
 func findBlockDevice(client *client.Client, machineID string, identifier string) (*entity.BlockDevice, error) {

--- a/maas/resource_maas_block_device_test.go
+++ b/maas/resource_maas_block_device_test.go
@@ -79,7 +79,7 @@ resource "maas_block_device" "test" {
 `, machine)
 }
 
-func testAccMAASBlockDeviceRename(machine, name, idPath string) string {
+func testAccMAASBlockDeviceWithIDPath(machine, name, idPath string) string {
 	return fmt.Sprintf(`
 data "maas_machine" "machine" {
   hostname = "%s"
@@ -158,7 +158,7 @@ func TestAccResourceMAASBlockDevice_stale(t *testing.T) {
 		CheckDestroy: testAccCheckMAASBlockDeviceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMAASBlockDeviceRename(machine, oldName, idPath),
+				Config: testAccMAASBlockDeviceWithIDPath(machine, oldName, idPath),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("maas_block_device.test", "name", oldName),
 					resource.TestCheckResourceAttr("maas_block_device.test", "id_path", idPath),
@@ -166,7 +166,7 @@ func TestAccResourceMAASBlockDevice_stale(t *testing.T) {
 			},
 			// rename the disk to check there is nothing stale remaining
 			{
-				Config: testAccMAASBlockDeviceRename(machine, newName, idPath),
+				Config: testAccMAASBlockDeviceWithIDPath(machine, newName, idPath),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("maas_block_device.test", "name", newName),
 					resource.TestCheckResourceAttr("maas_block_device.test", "id_path", idPath),

--- a/maas/resource_maas_block_device_test.go
+++ b/maas/resource_maas_block_device_test.go
@@ -3,9 +3,13 @@ package maas_test
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
+	"terraform-provider-maas/maas"
 	"terraform-provider-maas/maas/testutils"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -75,6 +79,22 @@ resource "maas_block_device" "test" {
 `, machine)
 }
 
+func testAccMAASBlockDeviceRename(machine, name, idPath string) string {
+	return fmt.Sprintf(`
+data "maas_machine" "machine" {
+  hostname = "%s"
+}
+
+resource "maas_block_device" "test" {
+  machine        = data.maas_machine.machine.id
+  name           = "%s"
+  size_gigabytes = 5
+  block_size     = 512
+  id_path        = "%s"
+}
+`, machine, name, idPath)
+}
+
 func TestAccResourceMAASBlockDevice_basic(t *testing.T) {
 	machine := os.Getenv("TF_ACC_BLOCK_DEVICE_MACHINE")
 
@@ -122,4 +142,94 @@ func TestAccResourceMAASBlockDevice_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccResourceMAASBlockDevice_stale(t *testing.T) {
+	machine := os.Getenv("TF_ACC_BLOCK_DEVICE_MACHINE")
+
+	oldName := acctest.RandomWithPrefix("tf-disk")
+	newName := acctest.RandomWithPrefix("tf-disk")
+	idPath := acctest.RandomWithPrefix("/dev/vd")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
+		Providers:    testutils.TestAccProviders,
+		ErrorCheck:   func(err error) error { return err },
+		CheckDestroy: testAccCheckMAASBlockDeviceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMAASBlockDeviceRename(machine, oldName, idPath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("maas_block_device.test", "name", oldName),
+					resource.TestCheckResourceAttr("maas_block_device.test", "id_path", idPath),
+				),
+			},
+			// rename the disk to check there is nothing stale remaining
+			{
+				Config: testAccMAASBlockDeviceRename(machine, newName, idPath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("maas_block_device.test", "name", newName),
+					resource.TestCheckResourceAttr("maas_block_device.test", "id_path", idPath),
+
+					testAccCheckMAASBlockDeviceStaleRemoved("maas_block_device.test", oldName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMAASBlockDeviceStaleRemoved(rn string, oldName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+
+		machineID := rs.Primary.Attributes["machine"]
+		client := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
+
+		devices, err := client.BlockDevices.Get(machineID)
+		if err != nil {
+			return fmt.Errorf("error fetching block devices: %s", err)
+		}
+
+		for _, d := range devices {
+			if d.Name == oldName {
+				return fmt.Errorf("Stale Block device %q still exists", oldName)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMAASBlockDeviceDestroy(s *terraform.State) error {
+	conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "maas_block_device" {
+			continue
+		}
+
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		machine := rs.Primary.Attributes["machine"]
+
+		response, err := conn.BlockDevice.Get(machine, id)
+		if err == nil {
+			if response != nil {
+				_ = conn.BlockDevice.Delete(machine, id)
+			}
+			continue
+		}
+
+		if !strings.Contains(err.Error(), "404 Not Found") {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/maas/resource_maas_block_device_test.go
+++ b/maas/resource_maas_block_device_test.go
@@ -223,6 +223,7 @@ func testAccCheckMAASBlockDeviceDestroy(s *terraform.State) error {
 			if response != nil {
 				_ = conn.BlockDevice.Delete(machine, id)
 			}
+
 			continue
 		}
 


### PR DESCRIPTION
## Description of changes

Introduce the searching by id_path as well as name, to attempt to find a disk definition that is preexisting before falling back to creating a new disk, to prevent disk renames from creating resources.

<!-- A clear and concise description of your changes here. -->

## Issue or ticket link (if applicable)

fixes: #396 

<!--
Please link the issue this PR addresses using GitHub’s keywords to automatically close related issues. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

e.g. Resolves: #XXX -->

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
