### PR TITLE
docs: fix missing tag guide

### DIFF
--- a/docs/guides/tagging.md
+++ b/docs/guides/tagging.md
@@ -1,18 +1,18 @@
 ---
-# generated using the Resource tagging.md.tmpl template
-page_title: "Resource tagging - terraform-provider-maas"
+# generated from templates/guides/tagging.md.tmpl - do not edit docs/guides/ directly
+page_title: "Resource tagging"
 subcategory: ""
 description: |-
-  MAAS implements tags in a number of ways to help manage and configure entities. This guide provides an overview of how to manage tags in MAAS using the terraform-provider-maas provider. Note that not all resources support tags.
+  MAAS implements tags in a number of ways to help manage and configure entities. This guide provides an overview of how to manage tags in MAAS using this provider. Note that not all resources support tags.
 ---
 
 # Resource tagging
 
-MAAS implements tags in a number of ways to help manage and configure entities. This guide provides an overview of how to manage tags in MAAS using the terraform-provider-maas provider. Note that not all resources support tags.
+MAAS implements tags in a number of ways to help manage and configure entities such as network interfaces and machines. This guide provides an overview of how to manage tags in MAAS using this provider. Note that not all resources support tags.
 
 ## Machine tags
 
-The `maas_tag` resource is used to manage Machine tags in MAAS. These tags can contain information such as kernel options and an XPATH definition that defines automatic tagging of machines. These tags cannot be used with other resources such as network interfaces or block devices. 
+The `maas_tag` resource is used to manage Machine tags in MAAS. These tags can contain information such as kernel options and an XPATH definition that defines automatic tagging of machines. These tags cannot be used with other resources such as network interfaces or block devices.
 
 `maas_instance.tags` refers to the name of these tags.
 
@@ -22,7 +22,7 @@ See the [maas_tag](https://github.com/maas/terraform-provider-maas/blob/master/d
 
 Other MAAS entities use simple strings as tags. They can be managed using the `tags` attribute on the relevant resource:
 
-```nohighlight
+```hcl
 resource "maas_network_interface_physical" "example" {
   ...
   tags = ["one", "two"]
@@ -40,19 +40,18 @@ Some examples of resources that support tags are provided below:
 
 Where possible, it's recommended to use the `tags` attribute on the relevant MAAS resources, such as `maas_network_interface_physical.tags`, to manage tags. Additional, dedicated tag resources such as `maas_network_interface_tag` are provided for cases where tags need to be managed separately from the specific resource, for example when chaining 2 terraform modules together to separate configuration and deployment, or when managing tags on resources that are not managed by Terraform.
 
-> [!WARNING] 
-> Using dedicated tag resources together with the `tags` attribute on MAAS specific resources, such as `maas_network_interface_physical.tags`, will cause conflicts and will overwrite the tags already set.
+~> **Warning** Using dedicated tag resources together with the `tags` attribute on MAAS specific resources, such as `maas_network_interface_physical.tags`, will cause conflicts and will overwrite the tags already set.
 
-If it's desirable to create interfaces using the `tags` attribute and later manage tags using the relevant dedicated resource, the `[ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes)` lifecycle argument can be used to ignore changes to a particular resource after creation
+If it's desirable to create interfaces using the `tags` attribute and later manage tags using the relevant dedicated resource, the [`ignore_changes`](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) lifecycle argument can be used to ignore changes to a particular resource after creation:
 
-```nohighlight
+```hcl
 resource "maas_network_interface_physical" "example" {
   # ...
   tags = ["one", "two"]
   lifecycle {
     ignore_changes = [
-    # ignore changes to tags after creation because they will be managed with the dedicated `maas_network_interface_tag` resource later on.
-    tags
+      # ignore changes to tags after creation because they will be managed with the dedicated `maas_network_interface_tag` resource later on.
+      tags
     ]
   }
 }

--- a/templates/guides/tagging.md.tmpl
+++ b/templates/guides/tagging.md.tmpl
@@ -1,0 +1,58 @@
+---
+# generated from templates/guides/tagging.md.tmpl - do not edit docs/guides/ directly
+page_title: "Resource tagging"
+subcategory: ""
+description: |-
+  MAAS implements tags in a number of ways to help manage and configure entities. This guide provides an overview of how to manage tags in MAAS using this provider. Note that not all resources support tags.
+---
+
+# Resource tagging
+
+MAAS implements tags in a number of ways to help manage and configure entities such as network interfaces and machines. This guide provides an overview of how to manage tags in MAAS using this provider. Note that not all resources support tags.
+
+## Machine tags
+
+The `maas_tag` resource is used to manage Machine tags in MAAS. These tags can contain information such as kernel options and an XPATH definition that defines automatic tagging of machines. These tags cannot be used with other resources such as network interfaces or block devices.
+
+`maas_instance.tags` refers to the name of these tags.
+
+See the [maas_tag](https://github.com/maas/terraform-provider-maas/blob/master/docs/resources/tag.md) resource for more information.
+
+## Other tags
+
+Other MAAS entities use simple strings as tags. They can be managed using the `tags` attribute on the relevant resource:
+
+```hcl
+resource "maas_network_interface_physical" "example" {
+  ...
+  tags = ["one", "two"]
+}
+```
+
+Some examples of resources that support tags are provided below:
+
+- [maas_network_interface_physical](https://github.com/maas/terraform-provider-maas/blob/master/docs/resources/network_interface_physical.md)
+- [maas_network_interface_bridge](https://github.com/maas/terraform-provider-maas/blob/master/docs/resources/network_interface_bridge.md)
+- [maas_network_interface_vlan](https://github.com/maas/terraform-provider-maas/blob/master/docs/resources/network_interface_vlan.md)
+- [maas_block_device](https://github.com/maas/terraform-provider-maas/blob/master/docs/resources/block_device.md)
+
+### Managing tags with dedicated resources
+
+Where possible, it's recommended to use the `tags` attribute on the relevant MAAS resources, such as `maas_network_interface_physical.tags`, to manage tags. Additional, dedicated tag resources such as `maas_network_interface_tag` are provided for cases where tags need to be managed separately from the specific resource, for example when chaining 2 terraform modules together to separate configuration and deployment, or when managing tags on resources that are not managed by Terraform.
+
+~> **Warning** Using dedicated tag resources together with the `tags` attribute on MAAS specific resources, such as `maas_network_interface_physical.tags`, will cause conflicts and will overwrite the tags already set.
+
+If it's desirable to create interfaces using the `tags` attribute and later manage tags using the relevant dedicated resource, the [`ignore_changes`](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) lifecycle argument can be used to ignore changes to a particular resource after creation:
+
+```hcl
+resource "maas_network_interface_physical" "example" {
+  # ...
+  tags = ["one", "two"]
+  lifecycle {
+    ignore_changes = [
+      # ignore changes to tags after creation because they will be managed with the dedicated `maas_network_interface_tag` resource later on.
+      tags
+    ]
+  }
+}
+```


### PR DESCRIPTION
## Description of changes

The guide on tags originally added in https://github.com/canonical/terraform-provider-maas/pull/290 does not show in the public docs on the registry. This is because the directory name `Guide` should be `guide`. 

The docs directory is generated anyway, so this guide has been migrated to a template with the help of an LLM. 

Additional minor rendering fixes were made to the guide.

## Issue or ticket link (if applicable)

<!--
Please link the issue this PR addresses using GitHub’s keywords to automatically close related issues. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

e.g. Resolves: #XXX -->
na - this issue was found during a local AI documentation audit. 

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [ ] I have added or updated the tests to reflect the changes.
- [ ] I have run the unit tests and they pass.
- [ ] I have run the acceptance tests and they pass.
