### PR TITLE
fix: add tags to block device nested schema

### DIFF
--- a/docs/data-sources/machine.md
+++ b/docs/data-sources/machine.md
@@ -63,3 +63,4 @@ Read-Only:
 - `name` (String)
 - `serial` (String)
 - `size_gigabytes` (Number)
+- `tags` (Set of String)

--- a/docs/resources/machine.md
+++ b/docs/resources/machine.md
@@ -159,6 +159,7 @@ Read-Only:
 - `name` (String)
 - `serial` (String)
 - `size_gigabytes` (Number)
+- `tags` (Set of String)
 
 ## Import
 

--- a/maas/data_source_maas_machine.go
+++ b/maas/data_source_maas_machine.go
@@ -55,6 +55,12 @@ func dataSourceMAASMachine() *schema.Resource {
 							Computed:    true,
 							Description: "The size of the block device (in GB).",
 						},
+						"tags": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "A set of tag names assigned to the block device.",
+						},
 					},
 				},
 			},
@@ -166,7 +172,7 @@ func dataSourceMachineRead(ctx context.Context, d *schema.ResourceData, meta any
 		"power_parameters": powerParamsJSON,
 		"pxe_mac_address":  machine.BootInterface.MACAddress,
 		"status":           machine.StatusName,
-		"block_devices":    getAllBlockDeviceMachineParameters(physicalBlockDevices),
+		"block_devices":    getShortBlockDeviceMachineParameters(physicalBlockDevices),
 	}
 	if err := setTerraformState(d, tfState); err != nil {
 		return diag.FromErr(err)

--- a/maas/data_source_maas_machine_test.go
+++ b/maas/data_source_maas_machine_test.go
@@ -36,6 +36,7 @@ func TestAccDataSourceMAASMachine_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.maas_machine.test", "status", "Ready"),
 					resource.TestCheckResourceAttrSet("data.maas_machine.test", "zone"),
 					resource.TestCheckResourceAttrSet("data.maas_machine.test", "block_devices.#"),
+					resource.TestCheckTypeSetElemAttr("data.maas_machine.test", "block_devices.1.tags.*", "test-tag"),
 					testAccCheckNoBlockDeviceWithName("data.maas_machine.test", "test-volume-group-virtual-test"),
 				),
 			},
@@ -78,6 +79,12 @@ resource "maas_block_device" "test" {
   name           = "test-block-device"
   id_path        = "/dev/sda"
   size_gigabytes = 2
+}
+
+resource "maas_block_device_tag" "test" {
+  machine         = maas_vm_host_machine.test.id
+  block_device_id = maas_block_device.test.id
+  tags            = ["test-tag"]
 }
 
 resource "maas_volume_group" "test" {

--- a/maas/resource_maas_machine.go
+++ b/maas/resource_maas_machine.go
@@ -116,6 +116,12 @@ func resourceMAASMachine() *schema.Resource {
 							Computed:    true,
 							Description: "The size of the block device (in GB).",
 						},
+						"tags": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "A set of tag names assigned to the block device.",
+						},
 					},
 				},
 			},
@@ -333,7 +339,7 @@ func resourceMachineRead(ctx context.Context, d *schema.ResourceData, meta any) 
 		return diag.FromErr(err)
 	}
 
-	blockDevices := getAllBlockDeviceMachineParameters(machine.BlockDeviceSet)
+	blockDevices := getShortBlockDeviceMachineParameters(machine.BlockDeviceSet)
 	if err := d.Set("block_devices", blockDevices); err != nil {
 		return diag.FromErr(err)
 	}
@@ -518,7 +524,10 @@ func getMachine(client *client.Client, identifier string) (*entity.Machine, erro
 	return nil, fmt.Errorf("machine (%s) not found", identifier)
 }
 
-func getAllBlockDeviceMachineParameters(blockDevices []entity.BlockDevice) []map[string]any {
+// Get a subset of block device parameters, which are deemed the minimum required to make the nested block_devices schema in the `machine` resource useful for users.
+// These are primarily identifiers, which can be used with a corresponding data source. The complete set of block device attributes
+// (e.g. partitions) are intentionally left out and should be obtained via a data source instead.
+func getShortBlockDeviceMachineParameters(blockDevices []entity.BlockDevice) []map[string]any {
 	// sort block devices by ID
 	sort.Slice(blockDevices, func(i, j int) bool {
 		return blockDevices[i].ID < blockDevices[j].ID
@@ -534,6 +543,7 @@ func getAllBlockDeviceMachineParameters(blockDevices []entity.BlockDevice) []map
 			"id_path":        blockDevice.IDPath,
 			"model":          blockDevice.Model,
 			"serial":         blockDevice.Serial,
+			"tags":           blockDevice.Tags,
 		}
 	}
 


### PR DESCRIPTION
## Description of changes

<!-- A clear and concise description of your changes here. -->
Added tags to the nested block device schema of both the data source and in the resource. 

Note that the block device attrs exposed are still a subset set of all block devices attrs possible. If additional attributes are required for filtering in the future, consider implementing the block device data source (see #394).

## Issue or ticket link (if applicable)

<!--
Please link the issue this PR addresses using GitHub’s keywords to automatically close related issues. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

e.g. Resolves: #XXX -->
Resolves: #468 

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
